### PR TITLE
Detect stalemate in KXK endgames

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -24,7 +24,7 @@
 
 class Position;
 
-extern Value evaluate(const Position& pos, Value& margin, const Value beta, const Value lazyMargin);
+extern Value evaluate(const Position& pos, Value& margin);
 extern std::string trace_evaluate(const Position& pos);
 extern void read_evaluation_uci_options(Color sideToMove);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,10 +81,6 @@ namespace {
   // Minimum depth for use of singular extension
   const Depth SingularExtensionDepth[] = { 8 * ONE_PLY, 6 * ONE_PLY };
 
-	// Lazy evaluation margins
-	const Value LazyMarginQS = Value(0x140);
-	const Value LazyMargin = Value(0x2E0);
-	
   // Futility margin for quiescence search
   const Value FutilityMarginQS = Value(0x80);
 
@@ -665,11 +661,8 @@ namespace {
     }
     else
     {
-        refinedValue = ss->eval = evaluate(pos, ss->evalMargin, PvNode ? VALUE_INFINITE : beta, LazyMargin);
-				if (ss->evalMargin == VALUE_INFINITE)
-					ss->evalMargin = VALUE_NONE;
-				else
-        	TT.store(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE, ss->eval, ss->evalMargin);
+        refinedValue = ss->eval = evaluate(pos, ss->evalMargin);
+        TT.store(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE, ss->eval, ss->evalMargin);
     }
 
     // Update gain for the parent non-capture move given the static position
@@ -1199,7 +1192,6 @@ split_point_start: // At split points actual search starts from here
     }
     else
     {
-				bool lazyCutoff = false;
         if (tte)
         {
             assert(tte->static_value() != VALUE_NONE);
@@ -1208,19 +1200,12 @@ split_point_start: // At split points actual search starts from here
             ss->eval = bestValue = tte->static_value();
         }
         else
-				{
-						ss->eval = bestValue = evaluate(pos, evalMargin, PvNode ? VALUE_INFINITE : beta, LazyMarginQS);
-						if (evalMargin == VALUE_INFINITE) {
-							evalMargin = VALUE_NONE;
-							lazyCutoff = true;
-						}
-				}
+            ss->eval = bestValue = evaluate(pos, evalMargin);
 
         // Stand pat. Return immediately if static value is at least beta
         if (bestValue >= beta)
         {
-            // Don't save in TT lazy eval score
-            if (!tte && !lazyCutoff)
+            if (!tte)
                 TT.store(pos.key(), value_to_tt(bestValue, ss->ply), BOUND_LOWER, DEPTH_NONE, MOVE_NONE, ss->eval, evalMargin);
 
             return bestValue;
@@ -1823,7 +1808,7 @@ void RootMove::insert_pv_in_tt(Position& pos) {
       // Don't overwrite existing correct entries
       if (!tte || tte->move() != pv[ply])
       {
-          v = (pos.in_check() ? VALUE_NONE : evaluate(pos, m, VALUE_INFINITE, VALUE_NONE));
+          v = (pos.in_check() ? VALUE_NONE : evaluate(pos, m));
           TT.store(k, VALUE_NONE, BOUND_NONE, DEPTH_NONE, pv[ply], v, m);
       }
       pos.do_move(pv[ply], *st++);


### PR DESCRIPTION
Also, handle cases where there are 2 bishops of the same color.

Shouldn't be much effect on ELO, as bench remains the same:
Before:
Total time (ms) : 3911
Nodes searched  : 5001819
Nodes/second    : 1278910

After:
Total time (ms) : 3895
Nodes searched  : 5001819
Nodes/second    : 1284164

Handles the cases in http://www.talkchess.com/forum/viewtopic.php?t=42335.

position fen K7/Q7/8/8/8/8/5p2/7k w - - 0 1
go depth 1
K7/8/8/8/8/8/5Q2/7k b - - 0 1
info depth 1 seldepth 2 score cp 678 nodes 66 nps 3000 time 22 multipv 1 pv a7f7
bestmove a7f7 ponder (none)

position fen 8/1p4p1/2k2R1p/8/8/8/1r5r/K7 b - - 0 1
go infinite
...
info depth 33 seldepth 76 score cp 1074 upperbound nodes 6348446 nps 2106319 time 3014 multipv 1 pv c6d5 f6f5 d5e4 f5e5 e4f4 e5f5 f4g3 f5g5 g3f3 g5f5 f3g3

Sample of FENs detected as stalemate:
K7/8/8/8/8/4N1Q1/8/7k b - - 0 1
K7/8/8/8/3Q4/6N1/8/4k3 b - - 0 1
K7/8/8/8/5Q2/7k/8/4N3 b - - 0 1
K7/8/8/8/5N1k/8/6Q1/8 b - - 0 1
K5Q1/8/8/8/8/8/5N1k/8 b - - 0 1
K7/8/8/8/4N3/5Q2/8/4k3 b - - 0 1
K7/8/1q6/8/8/8/k7/8 w - - 0 1
K7/8/1q6/8/8/8/8/k7 w - - 0 1
K7/8/1q6/8/8/k7/8/8 w - - 0 1
K7/8/1qk5/8/8/8/8/8 w - - 0 1
