### PR TITLE
Lazy eval

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -24,7 +24,7 @@
 
 class Position;
 
-extern Value evaluate(const Position& pos, Value& margin, const Value beta);
+extern Value evaluate(const Position& pos, Value& margin, const Value beta, const Value lazyMargin);
 extern std::string trace_evaluate(const Position& pos);
 extern void read_evaluation_uci_options(Color sideToMove);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -81,6 +81,10 @@ namespace {
   // Minimum depth for use of singular extension
   const Depth SingularExtensionDepth[] = { 8 * ONE_PLY, 6 * ONE_PLY };
 
+	// Lazy evaluation margins
+	const Value LazyMarginQS = Value(0x140);
+	const Value LazyMargin = Value(0x2E0);
+	
   // Futility margin for quiescence search
   const Value FutilityMarginQS = Value(0x80);
 
@@ -661,8 +665,11 @@ namespace {
     }
     else
     {
-        refinedValue = ss->eval = evaluate(pos, ss->evalMargin, VALUE_INFINITE);
-        TT.store(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE, ss->eval, ss->evalMargin);
+        refinedValue = ss->eval = evaluate(pos, ss->evalMargin, PvNode ? VALUE_INFINITE : beta, LazyMargin);
+				if (ss->evalMargin == VALUE_INFINITE)
+					ss->evalMargin = VALUE_NONE;
+				else
+        	TT.store(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE, ss->eval, ss->evalMargin);
     }
 
     // Update gain for the parent non-capture move given the static position
@@ -1192,6 +1199,7 @@ split_point_start: // At split points actual search starts from here
     }
     else
     {
+				bool lazyCutoff = false;
         if (tte)
         {
             assert(tte->static_value() != VALUE_NONE);
@@ -1200,13 +1208,19 @@ split_point_start: // At split points actual search starts from here
             ss->eval = bestValue = tte->static_value();
         }
         else
-            ss->eval = bestValue = evaluate(pos, evalMargin, PvNode ? VALUE_INFINITE : beta);
+				{
+						ss->eval = bestValue = evaluate(pos, evalMargin, PvNode ? VALUE_INFINITE : beta, LazyMarginQS);
+						if (evalMargin == VALUE_INFINITE) {
+							evalMargin = VALUE_NONE;
+							lazyCutoff = true;
+						}
+				}
 
         // Stand pat. Return immediately if static value is at least beta
         if (bestValue >= beta)
         {
             // Don't save in TT lazy eval score
-            if (!tte && bestValue < beta + KnightValueMidgame)
+            if (!tte && !lazyCutoff)
                 TT.store(pos.key(), value_to_tt(bestValue, ss->ply), BOUND_LOWER, DEPTH_NONE, MOVE_NONE, ss->eval, evalMargin);
 
             return bestValue;
@@ -1809,7 +1823,7 @@ void RootMove::insert_pv_in_tt(Position& pos) {
       // Don't overwrite existing correct entries
       if (!tte || tte->move() != pv[ply])
       {
-          v = (pos.in_check() ? VALUE_NONE : evaluate(pos, m, VALUE_INFINITE));
+          v = (pos.in_check() ? VALUE_NONE : evaluate(pos, m, VALUE_INFINITE, VALUE_NONE));
           TT.store(k, VALUE_NONE, BOUND_NONE, DEPTH_NONE, pv[ply], v, m);
       }
       pos.do_move(pv[ply], *st++);


### PR DESCRIPTION
This is more for a code review. It is based directly off of your lazy_eval branch, ported forward to current, and margin values tuned using a very basic method of trying a bunch of them automatically :). I'm running a match vs vanilla right now.

Tuned on bench:
Total time (ms) : 3704
Nodes searched : 5689260
Nodes/second : 1535977

vs vanilla
Total time (ms) : 3911
Nodes searched : 5001819
Nodes/second : 1278910
