### PR TITLE
Handle KBPPKNP better

### DIFF
--- a/src/endgame.h
+++ b/src/endgame.h
@@ -56,6 +56,7 @@ enum EndgameType {
   KBPKB,   // KBP vs KB
   KBPPKB,  // KBPP vs KB
   KBPKN,   // KBP vs KN
+  KBPPKNP, // KBPP vs KNP
   KNPK,    // KNP vs K
   KPKP     // KP vs KP
 };


### PR DESCRIPTION
This endgame can be a dead draw, with the same problem as KBPKN.

The code is a bit ugly...  But I can't think of a nicer way to detect the one passed pawn scenario.  In the case where there are no passed pawns, or both passed pawns, all bets are off for the drawiness of the position.

I'm running ELO tests right now, but I assume no ELO change.  Bench is the same.

I'll flatten to the single commit if the ELO tests pan out.  Or if you can think of a nicer way to write it :).
