### PR TITLE
Less pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -67,7 +67,7 @@ namespace {
   const Depth RazorDepth = 4 * ONE_PLY;
 
   // Dynamic razoring margin based on depth
-  inline Value razor_margin(Depth d) { return Value(0x200 + 0x10 * int(d)); }
+  inline Value razor_margin(Depth d) { return Value(0x200 + 0x28 * int(d)); }
 
   // Maximum depth for use of dynamic threat detection when null move fails low
   const Depth ThreatDepth = 5 * ONE_PLY;
@@ -212,7 +212,7 @@ void Search::init() {
 
   // Init futility move count array
   for (d = 0; d < 32; d++)
-      FutilityMoveCounts[d] = int(3.001 + 0.25 * pow(d, 2.0));
+      FutilityMoveCounts[d] = int(3.001 + 0.30 * pow(d, 2.15));
 }
 
 


### PR DESCRIPTION
Another fake pull request :).  More to start a discussion on the pruning in general.  The pruning right now is incredibly aggressive, and works quite well.  Dropping it back a tiny bit was +1 in 16k 2"+0.05 games self-play (obviously well with margin of error).

I wonder if pruning less aggressively would be more beneficial against other engines though.  I can start a gauntlet, but it probably wouldn't be very decisive.  More a philosophy question I guess :).
