### PR TITLE
Made some changes to allow building on Haiku

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,11 +20,18 @@
 ### Section 1. General Configuration
 ### ==========================================================================
 
+### Establish the operating system name
+UNAME = $(shell uname)
+
 ### Executable name
 EXE = stockfish
 
 ### Installation dir definitions
 PREFIX = /usr/local
+# Haiku has a non-standard filesystem layout
+ifeq ($(UNAME),Haiku)
+	PREFIX=/boot/common
+endif
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
@@ -229,7 +236,10 @@ LDFLAGS = $(EXTRALDFLAGS)
 
 ### On mingw use Windows threads, otherwise POSIX
 ifneq ($(comp),mingw)
-	LDFLAGS += -lpthread
+	# Haiku has pthreads in its libroot, so only link it in on other platforms
+	ifneq ($(UNAME),Haiku)
+		LDFLAGS += -lpthread
+	endif
 endif
 
 ifeq ($(os),osx)


### PR DESCRIPTION
I did this because I was using the chess GUI on Haiku called Puri, and wanted to compile a newer version of Stockfish for use with it.  The most important part of this commit is to not link in pthreads in Haiku since it is part of the OS's libroot.  If there was a configure file or the like, this could be handled using something like AC_SEARCH_LIBS.  It looks like you want to keep things simple by using a straight-forward Makefile, so I made these changes with as little change to the Makefile as possible. These changes could be handled in other ways, naturally, but I figured this was the simplest way to accomplish the intended goals.

The changes...
- First change: If Haiku is host platform, change installation prefix to
  /boot/common/bin
- Second change: Only link in pthreads if Haiku isn't host platform
