### PR TITLE
Break from aspiration window loop when Signals.stop is true only after outputting pv info dump

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -416,8 +416,6 @@ namespace {
                 for (size_t i = 0; i <= PVIdx; i++)
                     RootMoves[i].insert_pv_in_tt(pos);
 
-                // CHANGED TO HAPPEN before Signals.stop is checked below! Is
-                // this a problem?
                 // Send full PV info to GUI if we are going to leave the loop or
                 // if we have a fail high/low and we are deep in the search.
                 if ((bestValue > alpha && bestValue < beta) || SearchTime.elapsed() > 2000)


### PR DESCRIPTION
[Edited in a new lead paragraph because otherwise it was confusing]

Hello!

I noticed that the final iteration of the aspiration window loop produces no uci pv output. I made this change in case there is not some existing reason why that information should not be posted.

I noticed this thing when experimenting with nodes limits -- from reading the code, I got the impression that node limits would usually be exceeded, and only then would the search stop and the final info be reported. However in the stockfish uci output the nodes count was (nearly) always under the limit.

I did note, afterwards, that the Search Log does get the final info but it would be nice to have it in the uci dump as well, if there's no obstacle.

Cheers!
