### PR TITLE
Improved the Issues with the Seventh Rank Bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -651,13 +651,9 @@ Value do_evaluate(const Position& pos, Value& margin) {
             if (ei.pi->file_is_half_open(Us, f))
             {
                 if (ei.pi->file_is_half_open(Them, f))
-				{
-					score += RookOpenFileBonus;
-				}
+			score += RookOpenFileBonus;
                 else
-				{
-					score += RookHalfOpenFileBonus;
-				}
+			score += RookHalfOpenFileBonus;
             }
 
             // Penalize rooks which are trapped inside a king. Penalize more if


### PR DESCRIPTION
Closed for improvements to the code base.

In the current version, the computer gives a flat bonus to rooks and queens on the seventh rank, but it should be less if there are no pawns on the rank.

In this pull, the bonus is variable based on the amount of pawns on the rank.

Edit:
It may be possible to use this code to be more general purpose. I am going to work on it tonight.
## Test information

In a tournament series of 150 blitz games ran on two threads, the new version:
Won:  77 games
Drew: 43 games
Lost:  30 games

New version points: 81.5 / 150
Old version points:  68.5 / 150
Being a 4-5% advantage

Therefor, the new version yields a 28-35 ELO point increase.
