### PR TITLE
Improved View of the 7th Rank

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -599,6 +599,8 @@ Value do_evaluate(const Position& pos, Value& margin) {
 
         if (Piece == ROOK || Piece == QUEEN)
         {
+            Rank rook_rank = rank_of(s);
+          
             // Queen or rook on 7th rank
             if (   relative_rank(Us, s) == RANK_7
                 && relative_rank(Us, pos.king_square(Them)) == RANK_8)
@@ -607,8 +609,10 @@ Value do_evaluate(const Position& pos, Value& margin) {
             }
             // Pawns on same rank as rook or queen
             const Bitboard pawns = pos.pieces(Them, PAWN) & RankBB[rank_of(s)];
-            if (pawns)
-                score += (Piece == ROOK ? RookBonusPerPawn : QueenBonusPerPawn) * popcount<Max15>(pawns);
+            
+            if (rook_rank == RANK_8 || rook_rank == RANK_1)
+                if (pawns)
+                    score += (Piece == ROOK ? RookBonusPerPawn : QueenBonusPerPawn) * popcount<Max15>(pawns);
         }
 
         // Special extra evaluation for bishops


### PR DESCRIPTION
In the old version of evaluate.cpp, the 7th rank bonus was based on the sheer fact of the rook's position and the king's.

My revision devised this bonus into two parts. I kept the old bonus, but lowered it by a large margin. It also gives a bonus based on the amount of pawns on the rook's rank.

This change is based on the idea that a rook on the 7'th rank is useless (or next to) unless there are pawns on that rank.

The most promising part of this update is that most of the games resulted in a win or a loss, showing a large place for improvement on top of it.
