### PR TITLE
Don't null move when pin threats exist

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -23,13 +23,57 @@
 #include "types.h"
 
 class Position;
+class MaterialEntry;
+class PawnEntry;
+
+// Struct EvalInfo contains various information computed and collected
+// by the evaluation functions.
+struct EvalInfo {
+
+  // Pointers to material and pawn hash table entries
+  MaterialEntry* mi;
+  PawnEntry* pi;
+
+  // attackedBy[color][piece type] is a bitboard representing all squares
+  // attacked by a given color and piece type, attackedBy[color][0] contains
+  // all squares attacked by the given color.
+  Bitboard attackedBy[2][8];
+
+  // kingRing[color] is the zone around the king which is considered
+  // by the king safety evaluation. This consists of the squares directly
+  // adjacent to the king, and the three (or two, for a king on an edge file)
+  // squares two ranks in front of the king. For instance, if black's king
+  // is on g8, kingRing[BLACK] is a bitboard containing the squares f8, h8,
+  // f7, g7, h7, f6, g6 and h6.
+  Bitboard kingRing[2];
+
+  // kingAttackersCount[color] is the number of pieces of the given color
+  // which attack a square in the kingRing of the enemy king.
+  int kingAttackersCount[2];
+
+  // kingAttackersWeight[color] is the sum of the "weight" of the pieces of the
+  // given color which attack a square in the kingRing of the enemy king. The
+  // weights of the individual piece types are given by the variables
+  // QueenAttackWeight, RookAttackWeight, BishopAttackWeight and
+  // KnightAttackWeight in evaluate.cpp
+  int kingAttackersWeight[2];
+
+  // kingAdjacentZoneAttacksCount[color] is the number of attacks to squares
+  // directly adjacent to the king of the given color. Pieces which attack
+  // more than one square are counted multiple times. For instance, if black's
+  // king is on g8 and there's a white knight on g5, this knight adds
+  // 2 to kingAdjacentZoneAttacksCount[BLACK].
+  int kingAdjacentZoneAttacksCount[2];
+
+  bool pinThreat[2];
+};
 
 namespace Eval {
 
 extern Color RootColor;
 
 extern void init();
-extern Value evaluate(const Position& pos, Value& margin);
+extern Value evaluate(const Position& pos, Value& margin, EvalInfo& ei);
 extern std::string trace(const Position& pos);
 
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -479,6 +479,12 @@ namespace {
     }
   }
 
+  bool isSafeNull(const Position& pos, const EvalInfo& ei) {
+    const Color Us = pos.side_to_move();
+    const Color Them = Us == WHITE ? BLACK : WHITE;
+    return pos.non_pawn_material(Us)
+        && !ei.pinThreat[Them];
+  }
 
   // search<>() is the main search function for both PV and non-PV nodes and for
   // normal and SplitPoint nodes. When called just after a split point the search
@@ -591,6 +597,7 @@ namespace {
     }
 
     // Step 5. Evaluate the position statically and update parent's gain statistics
+    EvalInfo ei;
     if (inCheck)
         ss->eval = ss->evalMargin = refinedValue = VALUE_NONE;
     else if (tte)
@@ -600,10 +607,11 @@ namespace {
         ss->eval = tte->static_value();
         ss->evalMargin = tte->static_value_margin();
         refinedValue = refine_eval(tte, ttValue, ss->eval);
+        ei.pinThreat[WHITE] = ei.pinThreat[BLACK] = false;
     }
     else
     {
-        refinedValue = ss->eval = evaluate(pos, ss->evalMargin);
+        refinedValue = ss->eval = evaluate(pos, ss->evalMargin, ei);
         TT.store(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE, ss->eval, ss->evalMargin);
     }
 
@@ -645,7 +653,7 @@ namespace {
         && !inCheck
         &&  refinedValue - futility_margin(depth, 0) >= beta
         &&  abs(beta) < VALUE_MATE_IN_MAX_PLY
-        &&  pos.non_pawn_material(pos.side_to_move()))
+        &&  isSafeNull(pos, ei))
         return refinedValue - futility_margin(depth, 0);
 
     // Step 8. Null move search with verification search (is omitted in PV nodes)
@@ -655,7 +663,7 @@ namespace {
         && !inCheck
         &&  refinedValue >= beta
         &&  abs(beta) < VALUE_MATE_IN_MAX_PLY
-        &&  pos.non_pawn_material(pos.side_to_move()))
+        &&  isSafeNull(pos, ei))
     {
         ss->currentMove = MOVE_NULL;
 
@@ -1088,6 +1096,7 @@ split_point_start: // At split points actual search starts from here
     assert(depth <= DEPTH_ZERO);
 
     StateInfo st;
+    EvalInfo ei;
     Move ttMove, move, bestMove;
     Value ttValue, bestValue, value, evalMargin, futilityValue, futilityBase;
     bool inCheck, enoughMaterial, givesCheck, evasionPrunable;
@@ -1138,7 +1147,7 @@ split_point_start: // At split points actual search starts from here
             ss->eval = bestValue = tte->static_value();
         }
         else
-            ss->eval = bestValue = evaluate(pos, evalMargin);
+            ss->eval = bestValue = evaluate(pos, evalMargin, ei);
 
         // Stand pat. Return immediately if static value is at least beta
         if (bestValue >= beta)
@@ -1609,7 +1618,8 @@ void RootMove::insert_pv_in_tt(Position& pos) {
       // Don't overwrite existing correct entries
       if (!tte || tte->move() != pv[ply])
       {
-          v = (pos.in_check() ? VALUE_NONE : evaluate(pos, m));
+          EvalInfo ei;
+          v = (pos.in_check() ? VALUE_NONE : evaluate(pos, m, ei));
           TT.store(k, VALUE_NONE, BOUND_NONE, DEPTH_NONE, pv[ply], v, m);
       }
       pos.do_move(pv[ply], *st++);


### PR DESCRIPTION
Self testing at 40/60s+0.05s, this is how it looks so far.  So, still well within error bounds, but looking quite promising.

ELO: 8.35 +- 99%: 25.48 95%: 19.34
LOS: 95.76%
Wins: 177 Losses: 146 Draws: 925 Total: 1248

I've been working my way through the patches against 2.2.2 as well.  So far, the pinned piece check, and the pawn shelter change seem to be about even against komodo and critter.  In self play at 40/60s+0.05s, both look like improvements still though.  So, probably worth keeping them.  I'm going to test the undefended pieces change next.
