### PR TITLE
Automatic ARCH detection for Linux

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -162,6 +162,27 @@ ifeq ($(ARCH),osx-x86-32)
 	popcnt = no
 endif
 
+ifeq ($(strip $(ARCH)),)
+    #No ARCH given : using Linux automatic detection
+    arch = any
+    os = any
+    bits = $(shell getconf LONG_BIT)
+    prefetch = no
+    bsfq = no
+    #Detect sse
+    ifeq ($(bits),64)
+        ifeq ($(strip $(cat /proc/cpuinfo | grep sse)),)
+            prefetch = yes
+            bsfq = yes
+        endif        
+    endif
+    #Detect popcnt
+    ifeq ($(strip $(cat /proc/cpuinfo | grep popcnt)),)
+        popcnt = yes
+    else
+        popcnt = no
+    endif
+endif
 
 ### ==========================================================================
 ### Section 3. Low-level configuration


### PR DESCRIPTION
This allows to skip the 'ARCH' argument under Linux when calling 'make'.
