### PR TITLE
Allow prefetching on non-x86 platforms with gcc

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -223,7 +223,14 @@ void timed_wait(WaitCondition& sleepCond, Lock& sleepLock, int msec) {
 /// loaded from memory, that can be quite slow.
 #if defined(NO_PREFETCH)
 
-void prefetch(char*) {}
+void prefetch(char* addr)
+{
+  #if defined(__GNUC__)
+  //If the target does not support data prefetch, no other code is
+  //generated and GCC does not issue a warning.
+  __builtin_prefetch(addr);
+  #endif
+}
 
 #else
 


### PR DESCRIPTION
This allows to use prefetching on no-x86 platform. I tested if on an Allwinner A10 ARM processor (http://rhombus-tech.net/allwinner_a10/)
On this platform it enables pld asm instructions, with a 0.8% speedup.
## No-prefetch version (without patch) :

no prefetch
Total time (ms) : 51680
Nodes searched  : 5557146
Nodes/second    : 107529

`_Z8prefetchPc:
    .fnstart
.LFB2223:
    @ args = 0, pretend = 0, frame = 8
    @ frame_needed = 1, uses_anonymous_args = 0
    @ link register save eliminated.
    push    {r7}
    sub sp, sp, #12
    add r7, sp, #0
    str r0, [r7, #4]
    add r7, r7, #12
    mov sp, r7
    pop {r7}
    bx  lr
    .cantunwind
    .fnend
    .size   _Z8prefetchPc, .-_Z8prefetchPc
`
## Prefetch version (with patch) :

Total time (ms) : 51254
Nodes searched  : 5557146
Nodes/second    : 108423

`_Z8prefetchPc:
    .fnstart
.LFB2223:
    @ args = 0, pretend = 0, frame = 8
    @ frame_needed = 1, uses_anonymous_args = 0
    @ link register save eliminated.
    push    {r7}
    sub sp, sp, #12
    add r7, sp, #0
    str r0, [r7, #4]
    ldr r3, [r7, #4]
    pld [r3, #0]
    add r7, r7, #12
    mov sp, r7
    pop {r7}
    bx  lr
    .cantunwind
    .fnend`
