### PR TITLE
Improved compatibility with older versions of Mac OS X

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -231,7 +231,7 @@ ifeq ($(comp),clang)
 endif
 
 ifeq ($(os),osx)
-	CXXFLAGS += -arch $(arch)
+	CXXFLAGS += -arch $(arch) -mmacosx-version-min=10.6
 endif
 
 ### 3.3 General linker settings
@@ -246,7 +246,7 @@ ifneq ($(comp),mingw)
 endif
 
 ifeq ($(os),osx)
-	LDFLAGS += -arch $(arch)
+	LDFLAGS += -arch $(arch) -mmacosx-version-min=10.6
 endif
 
 ### 3.4 Debugging


### PR DESCRIPTION
Finally figured out how to support older versions of OS X like 10.6 and 10.7 when compiling Stockfish on my 10.8 machine. Added the minimum OS flag to the makefile.
