### PR TITLE
Tune ARM prefetching

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -319,6 +319,9 @@ ifeq ($(prefetch),yes)
 	    CXXFLAGS += -msse
 	    DEPENDFLAGS += -msse
     endif
+    ifeq ($(arch),arm-32)
+        CXXFLAGS += -DIS_32BYTES_CACHE_LINE
+    endif
 else
 	CXXFLAGS += -DNO_PREFETCH
 endif

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -240,7 +240,13 @@ void prefetch(char* addr) {
   _mm_prefetch(addr+64, _MM_HINT_T0); // 64 bytes ahead
 #  else
   __builtin_prefetch(addr);
+  #if defined(IS_32BYTES_CACHE_LINE)
+  __builtin_prefetch(addr+32);
+  #endif
   __builtin_prefetch(addr+64);
+  #if defined(IS_32BYTES_CACHE_LINE)
+  __builtin_prefetch(addr+96);
+  #endif
 #  endif
 }
 


### PR DESCRIPTION
This solves the '-msse' gcc parameter bug when compiling on ARM.
Also, it allows 32 bytes cache line prefetching ; this yields to a small performance gain :
#32 bytes prefetching (with patch)

Total time (ms) : 50875
Nodes searched  : 5557146
Nodes/second    : 109231  
#64 bytes prefetching (without patch)

Total time (ms) : 51254
Nodes searched : 5557146
Nodes/second : 108423
