### PR TITLE
Reduce cache impact of between_bb

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -45,7 +45,7 @@ Bitboard AdjacentFilesBB[FILE_NB];
 Bitboard ThisAndAdjacentFilesBB[FILE_NB];
 Bitboard InFrontBB[COLOR_NB][RANK_NB];
 Bitboard StepAttacksBB[PIECE_NB][SQUARE_NB];
-Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
+Bitboard BetweenBB_88[120];
 Bitboard DistanceRingsBB[SQUARE_NB][8];
 Bitboard ForwardBB[COLOR_NB][SQUARE_NB];
 Bitboard PassedPawnMask[COLOR_NB][SQUARE_NB];
@@ -223,15 +223,17 @@ void Bitboards::init() {
       PseudoAttacks[QUEEN][s] |= PseudoAttacks[  ROOK][s] = attacks_bb<  ROOK>(s, 0);
   }
 
-  for (Square s1 = SQ_A1; s1 <= SQ_H8; s1++)
-      for (Square s2 = SQ_A1; s2 <= SQ_H8; s2++)
-          if (PseudoAttacks[QUEEN][s1] & s2)
-          {
-              Square delta = (s2 - s1) / square_distance(s1, s2);
-
-              for (Square s = s1 + delta; s != s2; s += delta)
-                  BetweenBB[s1][s2] |= s;
-          }
+  for (int delta = 2; delta < 8; ++delta) {
+    for (Rank r = RANK_2; r < delta; r++)
+        BetweenBB_88[delta * 0x10] |= FILE_A | r;
+    for (File f = FILE_B; f < delta; f++)
+        BetweenBB_88[delta] |= f | RANK_1;
+    for (Square s = SQ_A1 + DELTA_NE; s != delta * 8 + delta; s += DELTA_NE)
+        BetweenBB_88[delta * 0x10 + delta] |= s;
+    for (Square s = SQ_A1 + Square(delta) + DELTA_NW; s != delta * 8; s += DELTA_NW)
+        BetweenBB_88[delta * 0x10 - delta] |= s;
+    BetweenBB_88[delta * 0x10 - delta] >>= delta;
+  }
 }
 
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -56,7 +56,7 @@ extern Bitboard AdjacentFilesBB[FILE_NB];
 extern Bitboard ThisAndAdjacentFilesBB[FILE_NB];
 extern Bitboard InFrontBB[COLOR_NB][RANK_NB];
 extern Bitboard StepAttacksBB[PIECE_NB][SQUARE_NB];
-extern Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
+extern Bitboard BetweenBB_88[120];
 extern Bitboard DistanceRingsBB[SQUARE_NB][8];
 extern Bitboard ForwardBB[COLOR_NB][SQUARE_NB];
 extern Bitboard PassedPawnMask[COLOR_NB][SQUARE_NB];
@@ -145,6 +145,11 @@ inline Bitboard in_front_bb(Color c, Square s) {
   return InFrontBB[c][rank_of(s)];
 }
 
+// x88_diff returns the difference between two squares in the 0x88 co-ordinate
+// system.
+inline int x88_diff(Square s1, Square s2) {
+  return s1 - s2 + (s1 | 7) - (s2 | 7);
+}
 
 /// between_bb returns a bitboard representing all squares between two squares.
 /// For instance, between_bb(SQ_C4, SQ_F7) returns a bitboard with the bits for
@@ -152,7 +157,9 @@ inline Bitboard in_front_bb(Color c, Square s) {
 /// 0 is returned.
 
 inline Bitboard between_bb(Square s1, Square s2) {
-  return BetweenBB[s1][s2];
+  if (s1 < s2)
+    std::swap(s1, s2);
+  return BetweenBB_88[x88_diff(s1, s2)] << s2;
 }
 
 
@@ -190,8 +197,8 @@ inline Bitboard attack_span_mask(Color c, Square s) {
 /// either on a straight or on a diagonal line.
 
 inline bool squares_aligned(Square s1, Square s2, Square s3) {
-  return  (BetweenBB[s1][s2] | BetweenBB[s1][s3] | BetweenBB[s2][s3])
-        & (     SquareBB[s1] |      SquareBB[s2] |      SquareBB[s3]);
+  return  (between_bb(s1, s2) | between_bb(s1, s3) | between_bb(s2, s3))
+        & (      SquareBB[s1] |       SquareBB[s2] |      SquareBB[s3]);
 }
 
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -579,7 +579,7 @@ Value do_evaluate(const Position& pos, Value& margin) {
         if (   (Piece == BISHOP || Piece == ROOK || Piece == QUEEN)
             && (PseudoAttacks[Piece][pos.king_square(Them)] & s))
         {
-            b = BetweenBB[s][pos.king_square(Them)] & pos.pieces();
+            b = between_bb(s, pos.king_square(Them)) & pos.pieces();
 
             assert(b);
 


### PR DESCRIPTION
This is a small speed win on my system (Linux, i7).  Idea from Gerd Isenberg here: http://www.talkchess.com/forum/viewtopic.php?t=46240.

Best of 10 bench runs after:
Total time (ms) : 2942
Nodes searched  : 5695710
Nodes/second    : 1935999

Best of 10 bench runs before:
Total time (ms) : 2968
Nodes searched  : 5695710
Nodes/second    : 1919039
