### PR TITLE
More futility pruning when coming from null move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1109,7 +1109,7 @@ split_point_start: // At split points actual search starts from here
     Key posKey;
     Move ttMove, move, bestMove;
     Value bestValue, value, ttValue, futilityValue, futilityBase, oldAlpha;
-    bool givesCheck, enoughMaterial, evasionPrunable;
+    bool givesCheck, enoughMaterial, evasionPrunable, fromNull;
     Depth ttDepth;
 
     // To flag BOUND_EXACT a node with eval above alpha and no available moves
@@ -1118,6 +1118,7 @@ split_point_start: // At split points actual search starts from here
 
     ss->currentMove = bestMove = MOVE_NONE;
     ss->ply = (ss-1)->ply + 1;
+    fromNull = (ss-1)->currentMove == MOVE_NULL;
 
     // Check for an instant draw or maximum ply reached
     if (pos.is_draw<false, false>() || ss->ply > MAX_PLY)
@@ -1207,7 +1208,8 @@ split_point_start: // At split points actual search starts from here
       {
           futilityValue =  futilityBase
                          + PieceValue[EG][pos.piece_on(to_sq(move))]
-                         + (type_of(move) == ENPASSANT ? PawnValueEg : VALUE_ZERO);
+                         + (type_of(move) == ENPASSANT ? PawnValueEg : VALUE_ZERO)
+                         - (fromNull ? PawnValueMg : VALUE_ZERO);
 
           if (futilityValue < beta)
           {


### PR DESCRIPTION
The idea for this came from the regression hunting.  Since disabling futility pruning after null move seemed to impact the ELO, I wondered about making futility pruning more aggressive.  Seems to work well!

After nearly 8k games:
ELO: 9.84  +- 99%: 10.07 95%: 7.65
LOS: 100.00%
Wins: 1315 Losses: 1090 Draws: 5545
