### PR TITLE
Adjust singular extension pruning by all/cut node type.  Bench: 3470580

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -90,7 +90,7 @@ namespace {
   Gains Gain;
 
   template <NodeType NT>
-  Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth);
+  Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, bool allNode);
 
   template <NodeType NT, bool InCheck>
   Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth);
@@ -346,7 +346,7 @@ namespace {
             {
                 // Search starts from ss+1 to allow referencing (ss-1). This is
                 // needed by update gains and ss copy when splitting at Root.
-                bestValue = search<Root>(pos, ss+1, alpha, beta, depth * ONE_PLY);
+                bestValue = search<Root>(pos, ss+1, alpha, beta, depth * ONE_PLY, true);
 
                 // Bring to front the best move. It is critical that sorting is
                 // done with a stable algorithm because all the values but the first
@@ -451,7 +451,7 @@ namespace {
                 Value rBeta = bestValue - 2 * PawnValueMg;
                 (ss+1)->excludedMove = RootMoves[0].pv[0];
                 (ss+1)->skipNullMove = true;
-                Value v = search<NonPV>(pos, ss+1, rBeta - 1, rBeta, (depth - 3) * ONE_PLY);
+                Value v = search<NonPV>(pos, ss+1, rBeta - 1, rBeta, (depth - 3) * ONE_PLY, false);
                 (ss+1)->skipNullMove = false;
                 (ss+1)->excludedMove = MOVE_NONE;
 
@@ -481,7 +481,7 @@ namespace {
   // here: This is taken care of after we return from the split point.
 
   template <NodeType NT>
-  Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
+  Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, bool allNode) {
 
     const bool PvNode   = (NT == PV || NT == Root || NT == SplitPointPV || NT == SplitPointRoot);
     const bool SpNode   = (NT == SplitPointPV || NT == SplitPointNonPV || NT == SplitPointRoot);
@@ -673,7 +673,7 @@ namespace {
         pos.do_null_move(st);
         (ss+1)->skipNullMove = true;
         nullValue = depth-R < ONE_PLY ? -qsearch<NonPV, false>(pos, ss+1, -beta, -alpha, DEPTH_ZERO)
-                                      : - search<NonPV>(pos, ss+1, -beta, -alpha, depth-R);
+                                      : -search<NonPV>(pos, ss+1, -beta, -alpha, depth-R, true);
         (ss+1)->skipNullMove = false;
         pos.undo_null_move();
 
@@ -688,7 +688,7 @@ namespace {
 
             // Do verification search at high depths
             ss->skipNullMove = true;
-            Value v = search<NonPV>(pos, ss, alpha, beta, depth-R);
+            Value v = search<NonPV>(pos, ss, alpha, beta, depth-R, allNode);
             ss->skipNullMove = false;
 
             if (v >= beta)
@@ -738,7 +738,7 @@ namespace {
             {
                 ss->currentMove = move;
                 pos.do_move(move, st, ci, pos.move_gives_check(move, ci));
-                value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, rdepth);
+                value = -search<NonPV>(pos, ss+1, -rbeta, -rbeta+1, rdepth, true);
                 pos.undo_move(move);
                 if (value >= rbeta)
                     return value;
@@ -753,7 +753,7 @@ namespace {
         Depth d = (PvNode ? depth - 2 * ONE_PLY : depth / 2);
 
         ss->skipNullMove = true;
-        search<PvNode ? PV : NonPV>(pos, ss, alpha, beta, d);
+        search<PvNode ? PV : NonPV>(pos, ss, alpha, beta, d, allNode);
         ss->skipNullMove = false;
 
         tte = TT.probe(posKey);
@@ -768,9 +768,9 @@ split_point_start: // At split points actual search starts from here
     singularExtensionNode =   !RootNode
                            && !SpNode
                            &&  depth >= (PvNode ? 6 * ONE_PLY : 8 * ONE_PLY)
+                           && !allNode
                            &&  ttMove != MOVE_NONE
                            && !excludedMove // Recursive singular search is not allowed
-                           && (tte->type() & BOUND_LOWER)
                            &&  tte->depth() >= depth - 3 * ONE_PLY;
 
     // Step 11. Loop through moves
@@ -842,10 +842,10 @@ split_point_start: // At split points actual search starts from here
       {
           assert(ttValue != VALUE_NONE);
 
-          Value rBeta = ttValue - int(depth);
+          Value rBeta = ttValue - int(depth) / 2;
           ss->excludedMove = move;
           ss->skipNullMove = true;
-          value = search<NonPV>(pos, ss, rBeta - 1, rBeta, depth / 2);
+          value = search<NonPV>(pos, ss, rBeta - 1, rBeta, depth / 2, true);
           ss->skipNullMove = false;
           ss->excludedMove = MOVE_NONE;
 
@@ -931,7 +931,7 @@ split_point_start: // At split points actual search starts from here
           Depth d = std::max(newDepth - ss->reduction, ONE_PLY);
           alpha = SpNode ? sp->alpha : alpha;
 
-          value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d);
+          value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, !allNode);
 
           doFullDepthSearch = (value > alpha && ss->reduction != DEPTH_ZERO);
           ss->reduction = DEPTH_ZERO;
@@ -946,7 +946,7 @@ split_point_start: // At split points actual search starts from here
           value = newDepth < ONE_PLY ?
                           givesCheck ? -qsearch<NonPV,  true>(pos, ss+1, -(alpha+1), -alpha, DEPTH_ZERO)
                                      : -qsearch<NonPV, false>(pos, ss+1, -(alpha+1), -alpha, DEPTH_ZERO)
-                                     : - search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth);
+                                     : - search<NonPV>(pos, ss+1, -(alpha+1), -alpha, newDepth, !allNode);
       }
 
       // Only for PV nodes do a full PV search on the first move or after a fail
@@ -956,7 +956,7 @@ split_point_start: // At split points actual search starts from here
           value = newDepth < ONE_PLY ?
                           givesCheck ? -qsearch<PV,  true>(pos, ss+1, -beta, -alpha, DEPTH_ZERO)
                                      : -qsearch<PV, false>(pos, ss+1, -beta, -alpha, DEPTH_ZERO)
-                                     : - search<PV>(pos, ss+1, -beta, -alpha, newDepth);
+                                     : - search<PV>(pos, ss+1, -beta, -alpha, newDepth, true);
       // Step 17. Undo move
       pos.undo_move(move);
 
@@ -1031,7 +1031,7 @@ split_point_start: // At split points actual search starts from here
           assert(bestValue < beta);
 
           thisThread->split<FakeSplit>(pos, ss, alpha, beta, &bestValue, &bestMove,
-                                       depth, threatMove, moveCount, &mp, NT);
+                                       depth, threatMove, moveCount, &mp, NT, allNode);
           if (bestValue >= beta)
               break;
       }
@@ -1678,13 +1678,13 @@ void Thread::idle_loop() {
 
           switch (sp->nodeType) {
           case Root:
-              search<SplitPointRoot>(pos, ss+1, sp->alpha, sp->beta, sp->depth);
+              search<SplitPointRoot>(pos, ss+1, sp->alpha, sp->beta, sp->depth, true);
               break;
           case PV:
-              search<SplitPointPV>(pos, ss+1, sp->alpha, sp->beta, sp->depth);
+              search<SplitPointPV>(pos, ss+1, sp->alpha, sp->beta, sp->depth, true);
               break;
           case NonPV:
-              search<SplitPointNonPV>(pos, ss+1, sp->alpha, sp->beta, sp->depth);
+              search<SplitPointNonPV>(pos, ss+1, sp->alpha, sp->beta, sp->depth, sp->allNode);
               break;
           default:
               assert(false);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -251,7 +251,7 @@ bool ThreadPool::slave_available(Thread* master) const {
 template <bool Fake>
 void Thread::split(Position& pos, Stack* ss, Value alpha, Value beta, Value* bestValue,
                    Move* bestMove, Depth depth, Move threatMove, int moveCount,
-                   MovePicker* movePicker, int nodeType) {
+                   MovePicker* movePicker, int nodeType, bool allNode) {
 
   assert(pos.pos_is_ok());
   assert(*bestValue <= alpha && alpha < beta && beta <= VALUE_INFINITE);
@@ -273,6 +273,7 @@ void Thread::split(Position& pos, Stack* ss, Value alpha, Value beta, Value* bes
   sp.alpha = alpha;
   sp.beta = beta;
   sp.nodeType = nodeType;
+  sp.allNode = allNode;
   sp.movePicker = movePicker;
   sp.moveCount = moveCount;
   sp.pos = &pos;
@@ -338,8 +339,8 @@ void Thread::split(Position& pos, Stack* ss, Value alpha, Value beta, Value* bes
 }
 
 // Explicit template instantiations
-template void Thread::split<false>(Position&, Stack*, Value, Value, Value*, Move*, Depth, Move, int, MovePicker*, int);
-template void Thread::split< true>(Position&, Stack*, Value, Value, Value*, Move*, Depth, Move, int, MovePicker*, int);
+template void Thread::split<false>(Position&, Stack*, Value, Value, Value*, Move*, Depth, Move, int, MovePicker*, int, bool);
+template void Thread::split< true>(Position&, Stack*, Value, Value, Value*, Move*, Depth, Move, int, MovePicker*, int, bool);
 
 
 // wait_for_think_finished() waits for main thread to go to sleep then returns

--- a/src/thread.h
+++ b/src/thread.h
@@ -68,6 +68,7 @@ struct SplitPoint {
   Value beta;
   int nodeType;
   Move threatMove;
+  bool allNode;
 
   // Const pointers to shared data
   MovePicker* movePicker;
@@ -104,7 +105,7 @@ struct Thread {
 
   template <bool Fake>
   void split(Position& pos, Search::Stack* ss, Value alpha, Value beta, Value* bestValue, Move* bestMove,
-             Depth depth, Move threatMove, int moveCount, MovePicker* movePicker, int nodeType);
+             Depth depth, Move threatMove, int moveCount, MovePicker* movePicker, int nodeType, bool allNode);
 
   SplitPoint splitPoints[MAX_SPLITPOINTS_PER_THREAD];
   Material::Table materialTable;


### PR DESCRIPTION
Tested at faster TC 5s+0.1s, I will run a test at 10+1 to see how things scale.

ELO: 14.49 +- 99%: 10.35 95%: 7.86
LOS: 100.00%
Wins: 1542 Losses: 1228 Draws: 4762

noise.py results:
Games: 7761 , result: [1587, 1270, 4904]
Estimated ELO: 14.600883954
Noise as function of number of games:
['309.41', '50.42', '141.68', '30.60', '10.90', '82.07', '132.36', '49.33', '68.97', '91.18', '86.19', '33.86', '78.90', '49.86', '35.36', '35.24', '44.79', '47.89', '34.90', '22.11', '15.96', '15.32', '14.85', '4.54', '5.56', '11.67', '16.45', '10.22', '8.56', '7.81', '6.78', '6.50', '7.32', '8.53', '10.60', '9.75', '10.24', '14.94', '20.77', '11.70', '13.13', '13.30', '3.24', '3.57', '8.87', '13.15', '9.88', '10.70', '15.03', '14.40', '15.10', '14.28', '12.15', '9.91', '8.51', '7.03', '4.15', '2.48', '4.18', '3.48']
