### PR TITLE
Stop search if only 1 legal move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -432,6 +432,10 @@ namespace {
         {
             bool stop = false; // Local variable, not the volatile Signals.stop
 
+            // Stop search if only 1 legal move
+ 	    if (depth == 1 && MoveList<LEGAL>(pos).size() == 1)
+	    stop = true; 
+
             // Take in account some extra time if the best move has changed
             if (depth > 4 && depth < 50 &&  PVSize == 1)
                 TimeMgr.pv_instability(BestMoveChanges, prevBestMoveChanges);


### PR DESCRIPTION
There is no point searching a move that is forced.
It wastes time while allowing computer opponents to fill hash with 100% accuracy.
Bench identical: 4922272
