### PR TITLE
Add KNPKB endgame

### DIFF
--- a/src/endgame.h
+++ b/src/endgame.h
@@ -58,6 +58,7 @@ enum EndgameType {
   KBPPKB,  // KBPP vs KB
   KBPKN,   // KBP vs KN
   KNPK,    // KNP vs K
+  KNPKB,   // KNP vs KB
   KPKP     // KP vs KP
 };
 


### PR DESCRIPTION
No change to bench numbers again :).

Another TCEC endgame failure, in a game vs Junior.  SF had the option to trade into a winning pawn endgame, and failed to do so.  PGN at bottom.

This FEN was one key position: 8/2Nb1k2/6pp/4Pp2/5K1P/5PP1/8/8 w - - 5 62.  SF master chooses h5 here, with a fail high, which goes into the drawn KNPKB ending.  With the patch, SF correctly chooses Ke3, which maintains chances to win.

```
[Event "nTCEC - Stage 2a - Season 1"]
[Site "http://www.tcec-chess.net"]
[Date "2013.03.05"]
[Round "11.3"]
[White "Stockfish 210213"]
[Black "Junior 13.3"]
[Result "1/2-1/2"]
[Variant "normal"]

1. d4 f5 2. g3 Nf6 3. Bg2 e6 4. c4 d5 5. Nh3 c6 6. O-O Bd6 7. Bf4 Be7 8. Nd2 O-O
9. Qb3 a5 10. Rfd1 Ne4 11. Be3 Nd7 12. Nf4 Ndf6 13. f3 a4 14. Qc2 Nxd2 15. Bxd2
dxc4 16. Qxc4 b5 17. Qc3 Qb6 18. Rac1 e5 19. Nd3 exd4 20. Qxc6 Qxc6 21. Rxc6
Bd7 22. Rcc1 Be6 23. Bb4 Rae8 24. Bxe7 Rxe7 25. Nb4 Bc4 26. Bf1 Rd7 27. Rd2 Re8
28. Rcd1 Rc7 29. Ra1 Rd8 30. Rc1 Rdd7 31. Rcd1 Re7 32. Ra1 Nd5 33. Nc2 Ne3
34. Nxd4 Bxa2 35. Nxb5 Rc5 36. Nd4 Bf7 37. Kf2 g6 38. Rd3 Nxf1 39. Kxf1 Rc4
40. b3 axb3 41. Nxb3 Kf8 42. Rd8+ Re8 43. Rxe8+ Bxe8 44. Kf2 Ke7 45. Ra7+ Bd7
46. Ke1 Rc3 47. Rb7 Rc2 48. Kd1 Rc4 49. Kd2 Kd6 50. Kd3 Rc7 51. Rxc7 Kxc7
52. Kd4 Kd6 53. Nc5 Bb5 54. e4 Be2 55. e5+ Ke7 56. Ke3 Bd1 57. Kf4 h6 58. h3
Kf7 59. h4 Bc2 60. Na6 Ba4 61. Nc7 Bd7 62. h5 g5+ 63. Ke3 Ba4 64. f4 Bd1
65. fxg5 hxg5 66. h6 Kg6 67. e6 f4+ 68. gxf4 gxf4+ 69. Kxf4 Bh5 70. Ke5 Kh7
71. Kf6 Kxh6 72. Na6 Bg4 73. e7 Bh5 74. Nc7 Bg6 75. Nd5 Be8 76. Ne3 Kh7 77. Nc4
Kh6 78. Nd2 Kh5 79. Nf3 Kg4 80. Nd4 Bh5 81. Ne6 Be8 82. Nc5 Kf3 83. Kf5 Ke3
84. Ke5 Ke2 85. Kf4 Kd2 86. Ne4+ Kd3 87. Ke5 Ke3 88. Nf6 Bf7 89. Nd5+ Kf3
90. Kf5 Ke2 91. Ke4 Be8 92. Nc3+ Kd2 93. Kd4 Kc2 94. Nd5 Kd1 95. Nf6 Bf7
96. Ne4 Be8 97. Ke3 Kc2 98. Nd6 Bd7 99. Kd4 Kd1 100. Kd3 Ba4 101. Nc4 Bb5
102. Kc3 Be8 103. Nb2+ Ke1 104. Kd3 Kf2 105. Nd1+ 1/2-1/2
```
