### PR TITLE
Error compiling with -flto in CXXFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -360,7 +360,7 @@ ifeq ($(comp),gcc)
 		GCC_MAJOR := `$(CXX) -dumpversion | cut -f1 -d.`
 		GCC_MINOR := `$(CXX) -dumpversion | cut -f2 -d.`
 		ifeq (1,$(shell expr \( $(GCC_MAJOR) \> 4 \) \| \( $(GCC_MAJOR) \= 4 \& $(GCC_MINOR) \>= 5 \)))
-			CXXFLAGS += -flto
+			CXXFLAGS += -flto -fuse-linker-plugin -fno-fat-lto-objects -flto-partition=none
 			LDFLAGS += $(CXXFLAGS)
 		endif
 	endif


### PR DESCRIPTION
When trying to make the project (make profile-build ARCH=x86-64) i got this error:

g++ -o stockfish benchmark.o bitbase.o bitboard.o book.o endgame.o evaluate.o main.o material.o misc
.o movegen.o movepick.o notation.o pawns.o position.o search.o thread.o timeman.o tt.o uci.o uciopti
on.o -lgcov -lpthread -Wall -Wcast-qual -fno-exceptions -fno-rtti -fprofile-generate -ansi -pedantic
 -Wno-long-long -Wextra -Wshadow -DNDEBUG -O3 -DIS_64BIT -msse -DUSE_BSFQ -flto
lto1: error interno del compilador: en add_symbol_to_partition, en lto/lto-partition.c:284

fixed it with this params in the commit, although i am not completely sure, if its the best way.

This is my gcc -v output:

Usando especificaciones internas.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-unknown-linux-gnu/4.8.1/lto-wrapper
Objetivo: x86_64-unknown-linux-gnu
Configurado con: /build/gcc/src/gcc-4.8.1/configure --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++ --enable-shared --enable-threads=posix --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-clocale=gnu --disable-libstdcxx-pch --enable-gnu-unique-object --enable-linker-build-id --enable-cloog-backend=isl --disable-cloog-version-check --enable-lto --enable-gold --enable-ld=default --enable-plugin --with-plugin-ld=ld.gold --with-linker-hash-style=gnu --disable-install-libiberty --disable-multilib --disable-libssp --disable-werror --enable-checking=release
Modelo de hilos: posix
gcc versión 4.8.1 (GCC)
