### PR TITLE
Fix stack size

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -303,7 +303,7 @@ namespace {
 
   void id_loop(Position& pos) {
 
-    Stack stack[MAX_PLY_PLUS_3], *ss = stack+2; // To allow referencing (ss-2)
+    Stack stack[MAX_PLY_PLUS_6], *ss = stack+2; // To allow referencing (ss-2)
     int depth, prevBestMoveChanges;
     Value bestValue, alpha, beta, delta;
 
@@ -1575,7 +1575,7 @@ moves_loop: // When in check and at SpNode search starts from here
 
 void RootMove::extract_pv_from_tt(Position& pos) {
 
-  StateInfo state[MAX_PLY_PLUS_3], *st = state;
+  StateInfo state[MAX_PLY_PLUS_6], *st = state;
   const TTEntry* tte;
   int ply = 0;
   Move m = pv[0];
@@ -1608,7 +1608,7 @@ void RootMove::extract_pv_from_tt(Position& pos) {
 
 void RootMove::insert_pv_in_tt(Position& pos) {
 
-  StateInfo state[MAX_PLY_PLUS_3], *st = state;
+  StateInfo state[MAX_PLY_PLUS_6], *st = state;
   const TTEntry* tte;
   int ply = 0;
 
@@ -1683,7 +1683,7 @@ void Thread::idle_loop() {
 
           Threads.mutex.unlock();
 
-          Stack stack[MAX_PLY_PLUS_3], *ss = stack+2; // To allow referencing (ss-2)
+          Stack stack[MAX_PLY_PLUS_6], *ss = stack+2; // To allow referencing (ss-2)
           Position pos(*sp->pos, this);
 
           std::memcpy(ss-2, sp->ss-2, 5 * sizeof(Stack));

--- a/src/types.h
+++ b/src/types.h
@@ -90,7 +90,7 @@ typedef uint64_t Bitboard;
 
 const int MAX_MOVES      = 192;
 const int MAX_PLY        = 100;
-const int MAX_PLY_PLUS_3 = MAX_PLY + 3;
+const int MAX_PLY_PLUS_6 = MAX_PLY + 6;
 
 /// A move needs 16 bits to be stored
 ///


### PR DESCRIPTION
In search:

```
ss->ply = (ss-1)->ply + 1;
ss->futilityMoveCount = 0;
(ss+1)->skipNullMove = false; (ss+1)->reduction = DEPTH_ZERO;
(ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;
```

and

Stack stack[MAX_PLY_PLUS_3], *ss = stack+2; // To allow referencing (ss-2)

and we abort the search when ply > MAX_PLY but this check is after (ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;

so at ply = 101 we access 3 slots after the end of the stack [MAX_PLY_PLUS_3]

I tested with

const int MAX_PLY_PLUS_3 = MAX_PLY + 6;

and no crash...

last line:

info depth 100 seldepth 101 score cp 0 nodes 15226668 nps 614052 time 24797 multipv 1 pv d1c2 g7h6 c2d2 h6g7 d2c3 g7f6 c3c2 f6g7 c2d3 g7h8 d3e3 h8g7 e3e2 g7h8 e2f3 h8g7 f3e2
info nodes 15226668 time 24797
