### PR TITLE
Fix best move lookup bug

### DIFF
--- a/src/book.cpp
+++ b/src/book.cpp
@@ -413,9 +413,13 @@ Move PolyglotBook::probe(const Position& pos, const string& fName, bool pickBest
       // Choose book move according to its score. If a move has a very
       // high score it has higher probability to be choosen than a move
       // with lower score. Note that first entry is always chosen.
-      if (   (sum && rkiss.rand<unsigned>() % sum < e.count)
-          || (pickBest && e.count == best))
+      if (pickBest) {
+          if (e.count == best) {
+              move = Move(e.move);
+          }
+      } else if (sum && rkiss.rand<unsigned>() % sum < e.count) {
           move = Move(e.move);
+      }
   }
 
   if (!move)


### PR DESCRIPTION
If the uci option 'Best Book Move' is set to true the lookup still
returns a move at random instead of the move with the highest
weight.
