### PR TITLE
Use flip_sq idea in endgame.cpp

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -197,7 +197,7 @@ Square get_flip_sq(const Position& pos, Color strongSide) {
 
   Square psq = pos.list<PAWN>(strongSide)[0];
 
-  return Square(7 * (8 * strongSide + (file_of(psq) >= FILE_E)));
+  return (FILE_H * (file_of(psq) >= FILE_E)) | (RANK_8 * int(strongSide));
 }
 
 Square operator^(Square s, Square flip_sq) {


### PR DESCRIPTION
This patch reduces lines of code in endgame.cpp

Bench is unchanged which gives me reasonable confidence I didn't make any mistakes.

The line with 7 \* (8 \* x + y) might be a bit hacky for your taste but hopefully you like the idea in general.

P.S. After this patch the "mirror" function is no longer used so you could remove it if you think that is appropriate.
