### PR TITLE
Fix divide by zero bug in very long games

### DIFF
--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -147,11 +147,12 @@ namespace {
     const double TMaxRatio   = (T == OptimumTime ? 1 : MaxRatio);
     const double TStealRatio = (T == OptimumTime ? 0 : StealRatio);
 
-    int thisMoveImportance = move_importance(currentPly) * slowMover / 100;
+    int thisMoveImportance = move_importance(currentPly) * slowMover;
     int otherMovesImportance = 0;
 
     for (int i = 1; i < movesToGo; ++i)
         otherMovesImportance += move_importance(currentPly + 2 * i);
+    otherMovesImportance *= 100;
 
     double ratio1 = (TMaxRatio * thisMoveImportance) / double(TMaxRatio * thisMoveImportance + otherMovesImportance);
     double ratio2 = (thisMoveImportance + TStealRatio * otherMovesImportance) / double(thisMoveImportance + otherMovesImportance);


### PR DESCRIPTION
If the game got late enough that move_importance(currentPly) \* slowMover / 100 rounds to 0 (around move 253 with the default slow mover value), then we ended up dividing 0 by 0 when only looking 1 move ahead.  This apparently caused the search to almost immediately abort and Stockfish would blunder in those long games.  So instead of dividing thisMoveImportance by 100 we multiply otherMoveImportance by 100.

Outside of the bug fix, this should only result in extremely tiny time allocation changes.
