### PR TITLE
Using bitfields to add 12 more previously wasted  bits to the key stored...

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -32,6 +32,7 @@ TranspositionTable TT; // Our global transposition table
 
 void TranspositionTable::set_size(size_t mbSize) {
 
+  assert(16 == sizeof(TTEntry));
   assert(msb((mbSize << 20) / sizeof(TTEntry)) < 32);
 
   uint32_t size = ClusterSize << msb((mbSize << 20) / sizeof(TTEntry[ClusterSize]));
@@ -71,10 +72,10 @@ void TranspositionTable::clear() {
 const TTEntry* TranspositionTable::probe(const Key key) const {
 
   const TTEntry* tte = first_entry(key);
-  uint32_t key32 = key >> 32;
+  const uint64_t key44 = key >> 20;
 
   for (unsigned i = 0; i < ClusterSize; ++i, ++tte)
-      if (tte->key() == key32)
+      if (tte->key() == key44)
           return tte;
 
   return NULL;
@@ -91,31 +92,30 @@ const TTEntry* TranspositionTable::probe(const Key key) const {
 
 void TranspositionTable::store(const Key key, Value v, Bound b, Depth d, Move m, Value statV) {
 
-  int c1, c2, c3;
   TTEntry *tte, *replace;
-  uint32_t key32 = key >> 32; // Use the high 32 bits as key inside the cluster
+  const uint64_t key44 = key >> 20; // Use the high 44 bits as key inside the cluster
 
   tte = replace = first_entry(key);
 
   for (unsigned i = 0; i < ClusterSize; ++i, ++tte)
   {
-      if (!tte->key() || tte->key() == key32) // Empty or overwrite old
+      if (!tte->key() || tte->key() == key44) // Empty or overwrite old
       {
           if (!m)
               m = tte->move(); // Preserve any existing ttMove
 
           replace = tte;
           break;
-      }
+      }   
 
       // Implement replace strategy
-      c1 = (replace->generation() == generation ?  2 : 0);
-      c2 = (tte->generation() == generation || tte->bound() == BOUND_EXACT ? -2 : 0);
-      c3 = (tte->depth() < replace->depth() ?  1 : 0);
+      int c1 = (replace->generation() == generation ?  2 : 0);
+      int c2 = (tte->generation() == generation || tte->bound() == BOUND_EXACT ? -2 : 0);
+      int c3 = (tte->depth() < replace->depth() ?  1 : 0);
 
       if (c1 + c2 + c3 > 0)
           replace = tte;
   }
 
-  replace->save(key32, v, b, d, m, generation, statV);
+  replace->save(key44, v, b, d, m, generation, statV);
 }

--- a/src/tt.h
+++ b/src/tt.h
@@ -25,42 +25,43 @@
 
 /// The TTEntry is the 128 bit transposition table entry, defined as below:
 ///
-/// key: 32 bit
-/// move: 16 bit
-/// bound type: 8 bit
+/// key: 44 bit
+/// depth: 10 bit
+/// bound type: 2 bit
 /// generation: 8 bit
+/// move: 16 bit
 /// value: 16 bit
-/// depth: 16 bit
 /// static value: 16 bit
 /// static margin: 16 bit
 
 struct TTEntry {
 
-  void save(uint32_t k, Value v, Bound b, Depth d, Move m, int g, Value ev) {
+  void save(uint64_t k, Value v, Bound b, Depth d, Move m, int g, Value ev) {
 
-    key32        = (uint32_t)k;
+    key44        = (uint64_t)k;
+    depth10      = (int64_t)d;
+    bound2       = (uint64_t)b;
+    generation8  = (uint64_t)g;
     move16       = (uint16_t)m;
-    bound8       = (uint8_t)b;
-    generation8  = (uint8_t)g;
     value16      = (int16_t)v;
-    depth16      = (int16_t)d;
     evalValue    = (int16_t)ev;
   }
   void set_generation(uint8_t g) { generation8 = g; }
 
-  uint32_t key() const      { return key32; }
-  Depth depth() const       { return (Depth)depth16; }
+  uint64_t key() const      { return key44; }
+  Depth depth() const       { return (Depth)depth10; }
   Move move() const         { return (Move)move16; }
   Value value() const       { return (Value)value16; }
-  Bound bound() const       { return (Bound)bound8; }
+  Bound bound() const       { return (Bound)bound2; }
   int generation() const    { return (int)generation8; }
   Value eval_value() const  { return (Value)evalValue; }
 
 private:
-  uint32_t key32;
+  uint64_t key44:44;
+  int64_t  depth10:10;
+  uint64_t bound2:2, generation8:8;
   uint16_t move16;
-  uint8_t bound8, generation8;
-  int16_t value16, depth16, evalValue;
+  int16_t value16, evalValue;
 };
 
 


### PR DESCRIPTION
... in TTentry.

This greatly reduces the likelihood of hard hash collisions and all the very difficult
to tract bugs potentially resulting from them.  I have verified in the debugger and some
extra code that this does actually prevent some collisions that happen in practice.
The standart bench doesn't search enough nodes to run into a collision so the signature remains the same.
However if you run:
stockfish bench 32 1 24 default depth  (this takes over 10 minutes on my machine)

you will see the signature change compared to the current master due to collision.
No functional change otherwise.
