### PR TITLE
Update TTentry when we calculate its static eval.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -590,7 +590,10 @@ namespace {
     {
         // Never assume anything on values stored in TT
         if ((ss->staticEval = eval = tte->eval_value()) == VALUE_NONE)
+        {
             eval = ss->staticEval = evaluate(pos);
+            const_cast<TTEntry*>(tte)->set_eval_value(eval);
+        }
 
         // Can ttValue be used as a better position evaluation?
         if (ttValue != VALUE_NONE)
@@ -1162,7 +1165,10 @@ moves_loop: // When in check and at SpNode search starts from here
         {
             // Never assume anything on values stored in TT
             if ((ss->staticEval = bestValue = tte->eval_value()) == VALUE_NONE)
+            {
                 ss->staticEval = bestValue = evaluate(pos);
+                const_cast<TTEntry*>(tte)->set_eval_value(bestValue);
+            }
 
             // Can ttValue be used as a better position evaluation?
             if (ttValue != VALUE_NONE)

--- a/src/tt.h
+++ b/src/tt.h
@@ -47,6 +47,7 @@ struct TTEntry {
     evalValue    = (int16_t)ev;
   }
   void set_generation(uint8_t g) { generation8 = g; }
+  void set_eval_value(Value ev) { evalValue = (int16_t)ev; }
 
   uint32_t key() const      { return key32; }
   Depth depth() const       { return (Depth)depth16; }


### PR DESCRIPTION
Marco, this updates the static eval in TTEntry if it's calculated after being VALUE_NONE.  It doesn't change the bench signature so I'm not sure if this should be a pull request or submitted to the test queue?
