### PR TITLE
better document null search window

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -635,8 +635,8 @@ namespace {
 
         pos.do_null_move(st);
         (ss+1)->skipNullMove = true;
-        nullValue = depth-R < ONE_PLY ? -qsearch<NonPV, false>(pos, ss+1, -beta, -alpha, DEPTH_ZERO)
-                                      : - search<NonPV>(pos, ss+1, -beta, -alpha, depth-R, !cutNode);
+        nullValue = depth-R < ONE_PLY ? -qsearch<NonPV, false>(pos, ss+1, -beta, -beta+1, DEPTH_ZERO)
+                                      : - search<NonPV>(pos, ss+1, -beta, -beta+1, depth-R, !cutNode);
         (ss+1)->skipNullMove = false;
         pos.undo_null_move();
 
@@ -651,8 +651,8 @@ namespace {
 
             // Do verification search at high depths
             ss->skipNullMove = true;
-            Value v = depth-R < ONE_PLY ? qsearch<NonPV, false>(pos, ss, alpha, beta, DEPTH_ZERO)
-                                        :  search<NonPV>(pos, ss, alpha, beta, depth-R, false);
+            Value v = depth-R < ONE_PLY ? qsearch<NonPV, false>(pos, ss, beta-1, beta, DEPTH_ZERO)
+                                        :  search<NonPV>(pos, ss, beta-1, beta, depth-R, false);
             ss->skipNullMove = false;
 
             if (v >= beta)


### PR DESCRIPTION
Hopefully this patch makes the code more:
- Self-documenting: Null search is always a zero window search, because it is testing for a fail high. It should never be done on a full window! The current code only works because we don't do it at PV nodes, and therefore (alpha, beta) = (beta-1, beta): that's the kind of "clever" trick we should avoid.
- Idiot-proof: If we want to enable null search at PV nodes, all we need to do now is comment out the !PvNode condition. It's that simple!

In theory, null search should not be done at PV nodes, because PV nodes should never fail high. But in practice, they DO fail high, because of aspiration windows, and search inconsistencies, for example. So it makes sense to keep that flexibility in the code.

No functional change.
