### PR TITLE
Followup smp fix

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -215,6 +215,8 @@ void MovePicker::score<EVASIONS>() {
 
 void MovePicker::generate_next() {
 
+  bool followUpMovesFound = false;
+  
   cur = moves;
 
   switch (++stage) {
@@ -248,9 +250,12 @@ void MovePicker::generate_next() {
               && followupmoves[i] != (cur+1)->move
               && followupmoves[i] != (cur+2)->move
               && followupmoves[i] != (cur+3)->move)
+          {
               (end++)->move = followupmoves[i];
+              followUpMovesFound = true;
+          }
 
-      if (followupmoves[1] && followupmoves[1] == followupmoves[0]) // Due to SMP races
+      if (followUpMovesFound && followupmoves[1] && followupmoves[1] == followupmoves[0]) // Due to SMP races
           (--end)->move = MOVE_NONE;
 
       return;


### PR DESCRIPTION
For some time a have added followup moves in the movepicker. Now i have seen a bug if the smp race condition is triggered. Under this condition the last move from the 'killer'-list is removed. But If the followup move but it is not used because it matched with a counter or killer move than the last counter (or even killler move if no countermove was found) is removed. This fix triggers the smp race condition only if a followup move is really added.
