### PR TITLE
Use FAST_GIVES_CHECK

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -51,6 +51,12 @@ using std::string;
 using Eval::evaluate;
 using namespace Search;
 
+// Fast wrapper for common case of pos.gives_check()
+#define FAST_GIVES_CHECK(pos, m, ci) \
+    ((type_of(m) == NORMAL && ci.dcCandidates == 0) \
+       ? (ci.checkSq[type_of(pos.piece_on(from_sq(m)))] & to_sq(m)) \
+	   : pos.gives_check(m, ci))
+
 namespace {
 
   // Set to true to force running with one thread. Used for debugging
@@ -772,7 +778,7 @@ moves_loop: // When in check and at SpNode search starts from here
 
       ext = DEPTH_ZERO;
       captureOrPromotion = pos.capture_or_promotion(move);
-      givesCheck = pos.gives_check(move, ci);
+      givesCheck = FAST_GIVES_CHECK(pos, move, ci);
       dangerous =   givesCheck
                  || type_of(move) != NORMAL
                  || pos.advanced_pawn_push(move);
@@ -1152,7 +1158,7 @@ moves_loop: // When in check and at SpNode search starts from here
     {
       assert(is_ok(move));
 
-      givesCheck = pos.gives_check(move, ci);
+      givesCheck = FAST_GIVES_CHECK(pos, move, ci);
 
       // Futility pruning
       if (   !PvNode


### PR DESCRIPTION
Test for common case which, when running default stockfish bench, avoids 96% of 19 million calls to pos.gives_check() , which is expensive due to passing of large CheckInfo structure.

Passed fishtest at STC
LLR: 2.97 (-2.94,2.94) [-1.50,4.50]
Total: 12441 W: 2333 L: 2196 D: 7912
http://tests.stockfishchess.org/tests/view/52f02d790ebc5901df50f887

Passed fishtest at LTC
LLR: 2.97 (-2.94,2.94) [0.00,6.00]
Total: 42175 W: 6702 L: 6409 D: 29064
http://tests.stockfishchess.org/tests/view/52f0dbe00ebc5901df50f8a0

No functional change.
