### PR TITLE
Fix a compiler warning.

### DIFF
--- a/src/notation.cpp
+++ b/src/notation.cpp
@@ -212,10 +212,10 @@ static string score_to_string(Value v) {
   return s.str();
 }
 
-string pretty_pv(Position& pos, int depth, Value value, int64_t msecs, Move pv[]) {
+string pretty_pv(Position& pos, int depth, Value value, uint64_t msecs, Move pv[]) {
 
-  const int64_t K = 1000;
-  const int64_t M = 1000000;
+  const uint64_t K = 1000;
+  const uint64_t M = 1000000;
 
   std::stack<StateInfo> st;
   Move* m = pv;

--- a/src/notation.h
+++ b/src/notation.h
@@ -30,6 +30,6 @@ std::string score_to_uci(Value v, Value alpha = -VALUE_INFINITE, Value beta = VA
 Move move_from_uci(const Position& pos, std::string& str);
 const std::string move_to_uci(Move m, bool chess960);
 const std::string move_to_san(Position& pos, Move m);
-std::string pretty_pv(Position& pos, int depth, Value score, int64_t msecs, Move pv[]);
+std::string pretty_pv(Position& pos, int depth, Value score, uint64_t msecs, Move pv[]);
 
 #endif // #ifndef NOTATION_H_INCLUDED


### PR DESCRIPTION
Latest master triggers a compiler warning due to comparing int64_t to uint64_t.

notation.cpp: In Funktion »std::string pretty_pv(Position&, int, Value, int64_t, Move*)«:
notation.cpp:230:30: Warnung: Vergleich zwischen vorzeichenbehafteten und vorzeichenlosen Ganzzahlausdrücken [-Wsign-compare]

This patch should fix it.

No functional change.
