### PR TITLE
Split delta with raised depth

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -327,7 +327,7 @@ namespace {
             // Reset aspiration window starting size
             if (depth >= 5)
             {
-                delta = Value(16);
+                depth > 23 ? delta = Value(16) : delta = Value(12);
                 alpha = std::max(RootMoves[PVIdx].prevScore - delta,-VALUE_INFINITE);
                 beta  = std::min(RootMoves[PVIdx].prevScore + delta, VALUE_INFINITE);
             }


### PR DESCRIPTION
Split delta value in aspiration window so that when search depth < 24 a smaller delta value is used. The idea is that the search is likely to be more accurate at lower depths and so we can exclude more possibilities, 25% to be exact.

Passed STC 
LLR: 2.96 (-2.94, 2.94) [-1.50, 4.50]
Total: 20430 W: 3775 L: 3618 D: 13037

And LTC 
LLR: 2.96 (-2.94, 2.94) [0.00, 6.00]
Total: 5032 W: 839 L: 715 D: 3478

Bench: 7451319