### PR TITLE
Queen vs. 3 minors imbalance

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -123,7 +123,7 @@ namespace {
         int b = pieceCount[Them][BISHOP] - pieceCount[Us][BISHOP];
 
         if ((n == 2 && b == 1) || (n == 1 && b == 2))
-            value -= 66 * 16;
+            value -= 88 * 16;
     }
 
     return value;


### PR DESCRIPTION
As suggested at talkchess.com

Passed both STC
LLR: 7.32 (-2.94,2.94) [-1.50,4.50]
Total: 98108 W: 18087 L: 17576 D: 62445

and LTC
LLR: 2.95 (-2.94,2.94) [0.00,6.00]
Total: 15082 W: 2417 L: 2248 D: 10417

bench: 7717336
