### PR TITLE
Remove QueenOn7th and QueenOnPawn (7473314)

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -162,9 +162,7 @@ namespace {
 
   const Score Tempo            = make_score(24, 11);
   const Score RookOn7th        = make_score(11, 20);
-  const Score QueenOn7th       = make_score( 3,  8);
   const Score RookOnPawn       = make_score(10, 28);
-  const Score QueenOnPawn      = make_score( 4, 20);
   const Score RookOpenFile     = make_score(43, 21);
   const Score RookSemiopenFile = make_score(19, 10);
   const Score BishopPawns      = make_score( 8, 12);
@@ -514,18 +512,17 @@ Value do_evaluate(const Position& pos) {
                 score += MinorBehindPawn;
         }
 
-        if (  (Pt == ROOK || Pt == QUEEN)
-            && relative_rank(Us, s) >= RANK_5)
+        if (Pt == ROOK && relative_rank(Us, s) >= RANK_5)
         {
-            // Major piece on 7th rank and enemy king trapped on 8th
+            // Rook on 7th rank and enemy king trapped on 8th
             if (   relative_rank(Us, s) == RANK_7
                 && relative_rank(Us, pos.king_square(Them)) == RANK_8)
-                score += Pt == ROOK ? RookOn7th : QueenOn7th;
+                score += RookOn7th;
 
-            // Major piece attacking enemy pawns on the same rank/file
+            // Rook piece attacking enemy pawns on the same rank/file
             Bitboard pawns = pos.pieces(Them, PAWN) & PseudoAttacks[ROOK][s];
             if (pawns)
-                score += popcount<Max15>(pawns) * (Pt == ROOK ? RookOnPawn : QueenOnPawn);
+                score += popcount<Max15>(pawns) * RookOnPawn;
         }
 
         // Special extra evaluation for rooks


### PR DESCRIPTION
Small simplification. Passed SPRT(-3,1) at STC and LTC:

http://tests.stockfishchess.org/tests/view/533d63ce0ebc59362fc5a150
http://tests.stockfishchess.org/tests/view/533ea9cb0ebc594b84c1a752

The rationale behind this is that I've never managed to add a Queen on 7th rank bonus in DiscoCheck, because it never showed to be positive (evne slightly) in testing. The only thing that worked is Rook on 7th rank.

In terms of SF code, it seemed natural to group it with QueenOnPawn as well as those are done together. I know you're against groupping in general, but when it comes to non regression test, you are being more conservative by groupping. If the group passes SPRT(-3,1) it's safer to commit, than test every component in SPRT(-3,1) and end up with the risk of commiting several -1 elo regression instead of just one -1 elo regression.

In chess terms, perhaps it's just easier to manouver a Queen (which can more also diagonaly) than a Rook. Therefore you can let the search do its job without needing eval ad-hoc terms to guide it. For the Rook which takes more moves to manouver such eval terms can be (marginally) useful.
