### PR TITLE
Rescale UCI scores to PawnValueEg

### DIFF
--- a/src/notation.cpp
+++ b/src/notation.cpp
@@ -43,7 +43,7 @@ string score_to_uci(Value v, Value alpha, Value beta) {
   stringstream s;
 
   if (abs(v) < VALUE_MATE_IN_MAX_PLY)
-      s << "cp " << v * 100 / int(PawnValueMg);
+      s << "cp " << v * 100 / int(PawnValueEg);
   else
       s << "mate " << (v > 0 ? VALUE_MATE - v + 1 : -VALUE_MATE - v) / 2;
 


### PR DESCRIPTION
This is more consistent with what other engines are doing. Often people that SF's scores are overblown.
In the end, it just boils down to the arbitrary way of rescaling them.

No functional change.
