### PR TITLE
Simplify Makefile by removing OS X targets

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -131,48 +131,13 @@ ifeq ($(ARCH),armv7)
 	bsfq = yes
 endif
 
-ifeq ($(ARCH),osx-ppc-32)
+ifeq ($(ARCH),ppc-32)
 	arch = ppc
-	os = osx
 endif
 
-ifeq ($(ARCH),osx-ppc-64)
-	arch = ppc64
-	os = osx
-	bits = 64
-endif
-
-ifeq ($(ARCH),linux-ppc-64)
+ifeq ($(ARCH),ppc-64)
 	arch = ppc64
 	bits = 64
-endif
-
-ifeq ($(ARCH),osx-x86-64)
-	arch = x86_64
-	os = osx
-	bits = 64
-	prefetch = yes
-	bsfq = yes
-	sse = yes
-endif
-
-ifeq ($(ARCH),osx-x86-64-modern)
-	arch = x86_64
-	os = osx
-	bits = 64
-	prefetch = yes
-	bsfq = yes
-	popcnt = yes
-	sse = yes
-endif
-
-ifeq ($(ARCH),osx-x86-32)
-	arch = i386
-	os = osx
-	prefetch = yes
-	bsfq = no
-	popcnt = no
-	sse = yes
 endif
 
 
@@ -226,7 +191,7 @@ else
 	profile_clean = gcc-profile-clean
 endif
 
-ifeq ($(os),osx)
+ifeq ($(UNAME),Darwin)
 	CXXFLAGS += -arch $(arch) -mmacosx-version-min=10.6
 	LDFLAGS += -arch $(arch) -mmacosx-version-min=10.6
 endif
@@ -255,7 +220,7 @@ ifeq ($(optimize),yes)
 	ifeq ($(comp),gcc)
 		CXXFLAGS += -O3
 
-		ifeq ($(os),osx)
+		ifeq ($(UNAME),Darwin)
 			ifeq ($(arch),i386)
 				CXXFLAGS += -mdynamic-no-pic
 			endif
@@ -274,7 +239,7 @@ ifeq ($(optimize),yes)
 	endif
 
 	ifeq ($(comp),icc)
-		ifeq ($(os),osx)
+		ifeq ($(UNAME),Darwin)
 			CXXFLAGS += -fast -mdynamic-no-pic
 		else
 			CXXFLAGS += -fast
@@ -284,8 +249,11 @@ ifeq ($(optimize),yes)
 	ifeq ($(comp),clang)
 		CXXFLAGS += -O3
 
-		ifeq ($(os),osx)
-			CXXFLAGS += -flto
+		ifeq ($(UNAME),Darwin)
+			ifeq ($(pext),no)
+				CXXFLAGS += -flto
+				LDFLAGS += $(CXXFLAGS)
+			endif
 			ifeq ($(arch),i386)
 				CXXFLAGS += -mdynamic-no-pic
 			endif
@@ -370,13 +338,9 @@ help:
 	@echo "x86-64-bmi2             > x86 64-bit with pext support"
 	@echo "x86-32                  > x86 32-bit with SSE support"
 	@echo "x86-32-old              > x86 32-bit fall back for old hardware"
-	@echo "linux-ppc-64            > PPC-Linux 64 bit"
-	@echo "osx-ppc-64              > PPC-Mac OS X 64 bit"
-	@echo "osx-ppc-32              > PPC-Mac OS X 32 bit"
-	@echo "osx-x86-64-modern       > x86-Mac OS X 64 bit with popcnt support"
-	@echo "osx-x86-64              > x86-Mac OS X 64 bit"
-	@echo "osx-x86-32              > x86-Mac OS X 32 bit"
-	@echo "armv7                   > ARMv7 32 bit"
+	@echo "ppc-64                  > PPC 64-bit"
+	@echo "ppc-32                  > PPC 32-bit"
+	@echo "armv7                   > ARMv7 32-bit"
 	@echo "general-64              > unspecified 64-bit"
 	@echo "general-32              > unspecified 32-bit"
 	@echo ""
@@ -467,7 +431,7 @@ config-sanity:
 	@test "$(optimize)" = "yes" || test "$(optimize)" = "no"
 	@test "$(arch)" = "any" || test "$(arch)" = "x86_64" || test "$(arch)" = "i386" || \
 	 test "$(arch)" = "ppc64" || test "$(arch)" = "ppc" || test "$(arch)" = "armv7"
-	@test "$(os)" = "any" || test "$(os)" = "osx"
+	@test "$(os)" = "any"
 	@test "$(bits)" = "32" || test "$(bits)" = "64"
 	@test "$(prefetch)" = "yes" || test "$(prefetch)" = "no"
 	@test "$(bsfq)" = "yes" || test "$(bsfq)" = "no"


### PR DESCRIPTION
Right now the Makefile is cluttered with OS X equivalents of all the x86 targets. We can get rid of all of them and just check UNAME against "Darwin" for the few OS X-specific things we need to do.

We also disable Clang LTO when using BMI2 instructions. For some reason, LLVM cannot find the PEXT instruction when using LTO. I don't know why, but disabling LTO for BMI2 fixes it.
