### PR TITLE
Enable BMI1 too when using BMI2 ARCH

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -293,7 +293,7 @@ endif
 ifeq ($(pext),yes)
 	CXXFLAGS += -DUSE_PEXT
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw))
-		CXXFLAGS += -mbmi2
+		CXXFLAGS += -mbmi -mbmi2
 	endif
 endif
 


### PR DESCRIPTION
Adding BMI1 allows the compiler to use _blsr_u64 automatically (the advertised 0.3% speed gain).
I verified that the compiler does not use this instruction with the -mbmi2 flag only. Also, all processors supporting BMI2 is also supporting BMI1.
No functional change.
