### PR TITLE
Changing contempt

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -337,7 +337,7 @@ namespace {
             {
                 bestValue = search<Root>(pos, ss, alpha, beta, depth * ONE_PLY, false);
                 
-                bestValue > VALUE_DRAW ? cf = 30 : cf = -30;
+                bestValue > VALUE_DRAW ? cf = 96 : cf = -96;
                 DrawValue[ RootColor] = VALUE_DRAW - Value(cf);
                 DrawValue[~RootColor] = VALUE_DRAW + Value(cf);
 


### PR DESCRIPTION
Adjust contempt according to our best value, allowing better utilisation of contempt factor.

Passed both STC 
LLR: 2.96 (-2.94,2.94) [-1.50,4.50]
Total: 9564 W: 1829 L: 1699 D: 6036

and LTC
LLR: 2.97 (-2.94,2.94) [0.00,6.00]
Total: 66608 W: 10524 L: 10121 D: 45963

Bench: 6783255
