### PR TITLE
Just random minor stuff I found while browsing the code.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -34,9 +34,8 @@ ifeq ($(UNAME),Haiku)
 endif
 BINDIR = $(PREFIX)/bin
 
-### Built-in benchmark for pgo-builds and signature
+### Built-in benchmark for pgo-builds
 PGOBENCH = ./$(EXE) bench 32 1 1 default time
-SIGNBENCH = ./$(EXE) bench
 
 ### Object files
 OBJS = benchmark.o bitbase.o bitboard.o book.o endgame.o evaluate.o main.o \

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -225,7 +225,7 @@ namespace {
   // interpolate() interpolates between a middlegame and an endgame score,
   // based on game phase. It also scales the return value by a ScaleFactor array.
 
-  Value interpolate(const Score& v, Phase ph, ScaleFactor sf) {
+  Value interpolate(Score v, Phase ph, ScaleFactor sf) {
 
     assert(-VALUE_INFINITE < mg_value(v) && mg_value(v) < VALUE_INFINITE);
     assert(-VALUE_INFINITE < eg_value(v) && eg_value(v) < VALUE_INFINITE);
@@ -734,7 +734,7 @@ namespace {
     ei.attackedBy[WHITE][ALL_PIECES] |= ei.attackedBy[WHITE][KING];
     ei.attackedBy[BLACK][ALL_PIECES] |= ei.attackedBy[BLACK][KING];
 
-    // Do not include in mobility squares protected by enemy pawns or occupied by our pieces
+    // Do not include in mobility squares protected by enemy pawns or occupied by our pawns or king
     Bitboard mobilityArea[] = { ~(ei.attackedBy[BLACK][PAWN] | pos.pieces(WHITE, PAWN, KING)),
                                 ~(ei.attackedBy[WHITE][PAWN] | pos.pieces(BLACK, PAWN, KING)) };
 
@@ -917,6 +917,8 @@ namespace Eval {
 
     const double MaxSlope = 30;
     const double Peak = 1280;
+
+    KingDanger[0][0] = KingDanger[1][0] = SCORE_ZERO;
 
     for (int t = 0, i = 1; i < 100; ++i)
     {

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -368,7 +368,7 @@ ExtMove* generate<EVASIONS>(const Position& pos, ExtMove* mlist) {
   Color us = pos.side_to_move();
   Square ksq = pos.king_square(us);
   Bitboard sliderAttacks = 0;
-  Bitboard sliders = pos.checkers() & ~pos.pieces(KNIGHT) & ~pos.pieces(PAWN);
+  Bitboard sliders = pos.checkers() & ~pos.pieces(KNIGHT, PAWN);
 
   // Find all the squares attacked by slider checkers. We will remove them from
   // the king evasions in order to skip known illegal moves, which avoids any


### PR DESCRIPTION
I added a line
KingDanger[0][0] = KingDanger[1][0] = SCORE_ZERO;
to Eval::init() because I don't see it explicitly initialized anywhere and we do read from those locations later.
Maybe there is some default init mechanism(I'm not aware of) that sets it to 0 for us in which case it's unnecessary?

Feel free to take or ignore anything you like.
