### PR TITLE
Add unreachable statement. No functional change.

### DIFF
--- a/src/bitcount.h
+++ b/src/bitcount.h
@@ -83,8 +83,8 @@ inline int popcount<CNT_HW_POPCNT>(Bitboard b) {
 
 #ifndef USE_POPCNT
 
+    unreachable();
   assert(false);
-  return b != 0; // Avoid 'b not used' warning
 
 #elif defined(_MSC_VER) && defined(__INTEL_COMPILER)
 

--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -613,7 +613,7 @@ ScaleFactor Endgame<KRPPKRP>::operator()(const Position& pos) const {
       case RANK_4: return ScaleFactor(15);
       case RANK_5: return ScaleFactor(20);
       case RANK_6: return ScaleFactor(40);
-      default: assert(false);
+      default: unreachable(); assert(false);
       }
   }
   return SCALE_FACTOR_NONE;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -290,6 +290,7 @@ void MovePicker::generate_next_stage() {
       return;
 
   default:
+      unreachable();
       assert(false);
   }
 }
@@ -379,6 +380,7 @@ Move MovePicker::next_move<false>() {
           return MOVE_NONE;
 
       default:
+          unreachable();
           assert(false);
       }
   }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -679,6 +679,7 @@ bool Position::gives_check(Move m, const CheckInfo& ci) const {
             && (attacks_bb<ROOK>(rto, (pieces() ^ kfrom ^ rfrom) | rto | kto) & ci.ksq);
   }
   default:
+      unreachable();
       assert(false);
       return false;
   }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1521,6 +1521,7 @@ void Thread::idle_loop() {
               search<SplitPointNonPV>(pos, ss, sp->alpha, sp->beta, sp->depth, sp->cutNode);
               break;
           default:
+              unreachable();
               assert(false);
           }
 

--- a/src/types.h
+++ b/src/types.h
@@ -97,6 +97,14 @@ const bool Is64Bit = true;
 const bool Is64Bit = false;
 #endif
 
+#if defined NDEBUG && (defined(__GNUC__) || defined(__clang__))
+#  define unreachable() __builtin_unreachable()
+#elif defined NDEBUG && (defined(__INTEL_COMPILER) || defined(_MSC_VER))
+#  define unreachable() __assume(0)
+#else
+#  define unreachable() do { } while(0)
+#endif
+
 typedef uint64_t Key;
 typedef uint64_t Bitboard;
 


### PR DESCRIPTION
Idea by Ronald de Man (https://groups.google.com/d/msg/fishcooking/7jgBrUXX0cs/GK8l36yGM7oJ) ; compiled and tested with gcc/icc/clang/intel compiler.
Here are the bench results showing small (~0.6%) speedup for gcc/icc ; msvc bench not included as they are in a virtual machine.
I know this is too much lines, but I have no idea on how to reduce this ;)

| master (gcc 4.8.1) | unreachable (gcc 4.8.1) |
| --- | --- |
| 2280255 | 2288071 |
| 2284457 | 2289882 |
| 2276069 | 2281454 |
| 2270710 | 2289278 |
| 2275472 | 2285058 |
| 2282654 | 2289278 |

| master (clang 3.3) | unreachable (clang 3.3) |
| --- | --- |
| 2224725 | 2222446 |
| 2223585 | 2220740 |
| 2223585 | 2222446 |
| 2223015 | 2221308 |
| 2225295 | 2221308 |
| 2224725 | 2221308 |

| master (intel compiler 14.0.2) | unreachable (intel compiler 14.0.2) |
| --- | --- |
| 2186609 | 2192686 |
| 2177282 | 2191579 |
| 2182211 | 2191579 |
| 2184408 | 2193240 |
| 2179471 | 2191026 |
| 2182211 | 2181662 |
