### PR TITLE
Visual Studio Ultimate 2013 Update 2 RC optimized builds

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -274,20 +274,18 @@ typedef union {
 
 inline Score make_score(int mg, int eg) {
   View v;
-  v.half.mg = (int16_t)mg - (eg < 0);
+  v.half.mg = (int16_t)mg - (uint16_t(eg) >> 15);
   v.half.eg = (int16_t)eg;
   return Score(v.full);
 }
 
 inline Value mg_value(Score s) {
-  View v;
-  v.full = s;
+  View v = {s};
   return Value(v.half.mg + (uint16_t(v.half.eg) >> 15));
 } 
 
 inline Value eg_value(Score s) {
-  View v;
-  v.full = s;
+  View v = {s};
   return Value(v.half.eg);
 }
 


### PR DESCRIPTION
When compiling using Visual C++ with optimization (such as `Maximize Speed (/O2)`), the compiler produces bad code in regards to the `Score` object. If you run the resulting code without `NDEBUG`, `bench` asserts an out-of-bounds `Score`:

> Position: 1/30
> Assertion failed: -VALUE_INFINITE < mg_value(v) && mg_value(v) < VALUE_INFINITE, file ....\repos\stockfish\src\evaluate.cpp, line 230

This may be related to this [bug in the Visual C++ compiler 64-bit code generator](http://info.prelert.com/blog/visual-cpp-code-generation-bug).

This patch fixes that.
