### PR TITLE
Symmetric evaluation

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -36,13 +36,14 @@
 #include "tt.h"
 #include "ucioption.h"
 
+const int Tempo = 17;
+
 namespace Search {
 
   volatile SignalsType Signals;
   LimitsType Limits;
   std::vector<RootMove> RootMoves;
   Position RootPos;
-  Color RootColor;
   Time::point SearchTime;
   StateStackPtr SetupStates;
 }
@@ -182,12 +183,11 @@ void Search::think() {
 
   static PolyglotBook book; // Defined static to initialize the PRNG only once
 
-  RootColor = RootPos.side_to_move();
-  TimeMgr.init(Limits, RootPos.game_ply(), RootColor);
+  TimeMgr.init(Limits, RootPos.game_ply(), RootPos.side_to_move());
 
   int cf = Options["Contempt Factor"] * PawnValueEg / 100; // From centipawns
-  DrawValue[ RootColor] = VALUE_DRAW - Value(cf);
-  DrawValue[~RootColor] = VALUE_DRAW + Value(cf);
+  DrawValue[ RootPos.side_to_move()] = VALUE_DRAW - Value(cf);
+  DrawValue[~RootPos.side_to_move()] = VALUE_DRAW + Value(cf);
 
   if (RootMoves.empty())
   {
@@ -216,8 +216,8 @@ void Search::think() {
       log << "\nSearching: "  << RootPos.fen()
           << "\ninfinite: "   << Limits.infinite
           << " ponder: "      << Limits.ponder
-          << " time: "        << Limits.time[RootColor]
-          << " increment: "   << Limits.inc[RootColor]
+          << " time: "        << Limits.time[RootPos.side_to_move()]
+          << " increment: "   << Limits.inc[RootPos.side_to_move()]
           << " moves to go: " << Limits.movestogo
           << "\n" << std::endl;
   }
@@ -485,7 +485,7 @@ namespace {
     bestValue = -VALUE_INFINITE;
     ss->currentMove = ss->ttMove = (ss+1)->excludedMove = bestMove = MOVE_NONE;
     ss->ply = (ss-1)->ply + 1;
-    (ss+1)->skipNullMove = false; (ss+1)->reduction = DEPTH_ZERO;
+    (ss+1)->skipNullMove = (ss+1)->nullChild = false; (ss+1)->reduction = DEPTH_ZERO;
     (ss+2)->killers[0] = (ss+2)->killers[1] = MOVE_NONE;
 
     // Used to send selDepth info to GUI
@@ -496,7 +496,7 @@ namespace {
     {
         // Step 2. Check for aborted search and immediate draw
         if (Signals.stop || pos.is_draw() || ss->ply > MAX_PLY)
-            return ss->ply > MAX_PLY && !inCheck ? evaluate(pos) : DrawValue[pos.side_to_move()];
+            return ss->ply > MAX_PLY && !inCheck ? evaluate(pos) + Tempo : DrawValue[pos.side_to_move()];
 
         // Step 3. Mate distance pruning. Even if we mate at the next move our score
         // would be at best mate_in(ss->ply+1), but if alpha is already bigger because
@@ -551,7 +551,7 @@ namespace {
     {
         // Never assume anything on values stored in TT
         if ((ss->staticEval = eval = tte->eval_value()) == VALUE_NONE)
-            eval = ss->staticEval = evaluate(pos);
+            eval = ss->staticEval = evaluate(pos) + Tempo;
 
         // Can ttValue be used as a better position evaluation?
         if (ttValue != VALUE_NONE)
@@ -560,7 +560,7 @@ namespace {
     }
     else
     {
-        eval = ss->staticEval = evaluate(pos);
+        eval = ss->staticEval = ss->nullChild ? -(ss-1)->staticEval + 2 * Tempo : evaluate(pos) + Tempo;
         TT.store(posKey, VALUE_NONE, BOUND_NONE, DEPTH_NONE, MOVE_NONE, ss->staticEval);
     }
 
@@ -620,10 +620,10 @@ namespace {
                  + int(eval - beta) / PawnValueMg * ONE_PLY;
 
         pos.do_null_move(st);
-        (ss+1)->skipNullMove = true;
+        (ss+1)->skipNullMove = (ss+1)->nullChild = true;
         nullValue = depth-R < ONE_PLY ? -qsearch<NonPV, false>(pos, ss+1, -beta, -beta+1, DEPTH_ZERO)
                                       : - search<NonPV, false>(pos, ss+1, -beta, -beta+1, depth-R, !cutNode);
-        (ss+1)->skipNullMove = false;
+        (ss+1)->skipNullMove = (ss+1)->nullChild = false;
         pos.undo_null_move();
 
         if (nullValue >= beta)
@@ -1071,7 +1071,7 @@ moves_loop: // When in check and at SpNode search starts from here
 
     // Check for an instant draw or if the maximum ply has been reached
     if (pos.is_draw() || ss->ply > MAX_PLY)
-        return ss->ply > MAX_PLY && !InCheck ? evaluate(pos) : DrawValue[pos.side_to_move()];
+        return ss->ply > MAX_PLY && !InCheck ? evaluate(pos) + Tempo : DrawValue[pos.side_to_move()];
 
     // Decide whether or not to include checks: this fixes also the type of
     // TT entry depth that we are going to use. Note that in qsearch we use
@@ -1108,7 +1108,7 @@ moves_loop: // When in check and at SpNode search starts from here
         {
             // Never assume anything on values stored in TT
             if ((ss->staticEval = bestValue = tte->eval_value()) == VALUE_NONE)
-                ss->staticEval = bestValue = evaluate(pos);
+                ss->staticEval = bestValue = evaluate(pos) + Tempo;
 
             // Can ttValue be used as a better position evaluation?
             if (ttValue != VALUE_NONE)
@@ -1116,7 +1116,7 @@ moves_loop: // When in check and at SpNode search starts from here
                     bestValue = ttValue;
         }
         else
-            ss->staticEval = bestValue = evaluate(pos);
+            ss->staticEval = bestValue = ss->nullChild ? -(ss-1)->staticEval + 2 * Tempo : evaluate(pos) + Tempo;
 
         // Stand pat. Return immediately if static value is at least beta
         if (bestValue >= beta)

--- a/src/search.h
+++ b/src/search.h
@@ -46,6 +46,7 @@ struct Stack {
   Depth reduction;
   Value staticEval;
   int skipNullMove;
+  bool nullChild;
 };
 
 
@@ -101,7 +102,6 @@ extern volatile SignalsType Signals;
 extern LimitsType Limits;
 extern std::vector<RootMove> RootMoves;
 extern Position RootPos;
-extern Color RootColor;
 extern Time::point SearchTime;
 extern StateStackPtr SetupStates;
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -197,11 +197,7 @@ void UCI::loop(int argc, char* argv[]) {
                     << "\n"       << Options
                     << "\nuciok"  << sync_endl;
 
-      else if (token == "eval")
-      {
-          Search::RootColor = pos.side_to_move(); // Ensure it is set
-          sync_cout << Eval::trace(pos) << sync_endl;
-      }
+      else if (token == "eval")       sync_cout << Eval::trace(pos) << sync_endl;
       else if (token == "ucinewgame") { /* Avoid returning "Unknown command" */ }
       else if (token == "go")         go(pos, is);
       else if (token == "position")   position(pos, is);
@@ -209,6 +205,7 @@ void UCI::loop(int argc, char* argv[]) {
       else if (token == "flip")       pos.flip();
       else if (token == "bench")      benchmark(pos, is);
       else if (token == "d")          sync_cout << pos.pretty() << sync_endl;
+      else if (token == "eval")       sync_cout << Eval::trace(pos) << sync_endl;
       else if (token == "isready")    sync_cout << "readyok" << sync_endl;
       else
           sync_cout << "Unknown command: " << cmd << sync_endl;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -67,8 +67,7 @@ void init(OptionsMap& o) {
   o["Passed Pawns (Midgame)"]   << Option(100, 0, 200, on_eval);
   o["Passed Pawns (Endgame)"]   << Option(100, 0, 200, on_eval);
   o["Space"]                    << Option(100, 0, 200, on_eval);
-  o["Aggressiveness"]           << Option(100, 0, 200, on_eval);
-  o["Cowardice"]                << Option(100, 0, 200, on_eval);
+  o["King Safety"]              << Option(110, 0, 200, on_eval);
   o["Min Split Depth"]          << Option(0, 0, 12, on_threads);
   o["Threads"]                  << Option(1, 1, MAX_THREADS, on_threads);
   o["Hash"]                     << Option(32, 1, 16384, on_hash_size);


### PR DESCRIPTION
- symmetrize king safety.
- symmetrize ad hoc eval terms: hanging + R and Q contact check.
- move Tempo outside eval and into the search, in order to have a fully symmetric eval.
- deduce eval from parent node after null search, to avoid unnecessary evaluate() calls: verified bench unchanged by this (ie. non functional speedup).

bench 7649396.
