### PR TITLE
Fix MSVC compiler/linker warnings

### DIFF
--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -27,6 +27,8 @@ namespace {
   template<CastlingRight Cr, bool Checks, bool Chess960>
   ExtMove* generate_castling(const Position& pos, ExtMove* mlist, Color us, const CheckInfo* ci) {
 
+    ci; // To remove unreference formal parameter warning in MSVC
+
     static const bool KingSide = (Cr == WHITE_OO || Cr == BLACK_OO);
 
     if (pos.castling_impeded(Cr) || !pos.can_castle(Cr))

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -226,7 +226,8 @@ void Position::set(const string& fenStr, bool isChess960, Thread* th) {
       incremented after Black's move.
 */
 
-  char col, row, token;
+  unsigned char token;
+  char col, row;
   size_t idx;
   Square sq = SQ_A8;
   std::istringstream ss(fenStr);
@@ -1133,12 +1134,13 @@ bool Position::is_draw() const {
 }
 
 
+static unsigned char toggle_case(unsigned char c) {
+  return unsigned char(islower(c) ? toupper(c) : tolower(c));
+}
+
+
 /// Position::flip() flips position with the white and black sides reversed. This
 /// is only useful for debugging e.g. for finding evaluation symmetry bugs.
-
-static char toggle_case(char c) {
-  return char(islower(c) ? toupper(c) : tolower(c));
-}
 
 void Position::flip() {
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -139,7 +139,7 @@ void Search::init() {
           Reductions[0][0][hd][mc] += ONE_PLY;
 
       else if (Reductions[0][0][hd][mc] > 1 * ONE_PLY)
-          Reductions[0][0][hd][mc] += ONE_PLY / 2;
+          Reductions[0][0][hd][mc] += int8_t(ONE_PLY / 2);
   }
 
   // Init futility move count array

--- a/src/types.h
+++ b/src/types.h
@@ -337,6 +337,8 @@ inline Score operator/(Score s, int i) {
   return make_score(mg_value(s) / i, eg_value(s) / i);
 }
 
+CACHE_LINE_ALIGNMENT
+
 extern Value PieceValue[PHASE_NB][PIECE_NB];
 
 struct ExtMove {


### PR DESCRIPTION
Sometimes the `generate_castling` template `ci` parameter is optimized away
`is____` functions require an `unsigned char` instead of a `char`
Casting to the appropriate type is required
`PieceValue` should always have `CACHE_LINE_ALIGNMENT`

No functional change
