### PR TITLE
Add a .gitignore file; use defined operator for inverting a color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+src/*.o
+.tags
+src/stockfish
+src/.depend

--- a/src/bitbase.cpp
+++ b/src/bitbase.cpp
@@ -146,7 +146,7 @@ namespace {
     // as WIN, the position is classified WIN otherwise the current position is
     // classified UNKNOWN.
 
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
+    const Color Them = ~Us;
 
     Result r = INVALID;
     Bitboard b = StepAttacksBB[KING][Us == WHITE ? wksq : bksq];

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -422,7 +422,7 @@ Value do_evaluate(const Position& pos) {
   template<Color Us>
   void init_eval_info(const Position& pos, EvalInfo& ei) {
 
-    const Color  Them = (Us == WHITE ? BLACK : WHITE);
+    const Color  Them = ~Us;
     const Square Down = (Us == WHITE ? DELTA_S : DELTA_N);
 
     ei.pinnedPieces[Us] = pos.pinned_pieces(Us);
@@ -448,7 +448,7 @@ Value do_evaluate(const Position& pos) {
   template<PieceType Piece, Color Us>
   Score evaluate_outposts(const Position& pos, EvalInfo& ei, Square s) {
 
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
+    const Color Them = ~Us;
 
     assert (Piece == BISHOP || Piece == KNIGHT);
 
@@ -479,7 +479,7 @@ Value do_evaluate(const Position& pos) {
     Square s;
     Score score = SCORE_ZERO;
 
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
+    const Color Them = ~Us;
     const Square* pl = pos.list<Piece>(Us);
 
     ei.attackedBy[Us][Piece] = 0;
@@ -605,7 +605,7 @@ Value do_evaluate(const Position& pos) {
   template<Color Us, bool Trace>
   Score evaluate_pieces_of_color(const Position& pos, EvalInfo& ei, Score* mobility) {
 
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
+    const Color Them = ~Us;
 
     // Do not include in mobility squares protected by enemy pawns or occupied by our pieces
     const Bitboard mobilityArea = ~(ei.attackedBy[Them][PAWN] | pos.pieces(Us, PAWN, KING));
@@ -631,7 +631,7 @@ Value do_evaluate(const Position& pos) {
   template<Color Us, bool Trace>
   Score evaluate_king(const Position& pos, const EvalInfo& ei) {
 
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
+    const Color Them = ~Us;
 
     Bitboard undefended, b, b1, b2, safe;
     int attackUnits;
@@ -741,7 +741,7 @@ Value do_evaluate(const Position& pos) {
   template<Color Us, bool Trace>
   Score evaluate_threats(const Position& pos, const EvalInfo& ei) {
 
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
+    const Color Them = ~Us;
 
     Bitboard b, undefendedMinors, weakEnemies;
     Score score = SCORE_ZERO;
@@ -783,7 +783,7 @@ Value do_evaluate(const Position& pos) {
   template<Color Us, bool Trace>
   Score evaluate_passed_pawns(const Position& pos, const EvalInfo& ei) {
 
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
+    const Color Them = ~Us;
 
     Bitboard b, squaresToQueen, defendedSquares, unsafeSquares, supportingPawns;
     Score score = SCORE_ZERO;
@@ -914,7 +914,7 @@ Value do_evaluate(const Position& pos) {
   template<Color Us>
   int evaluate_space(const Position& pos, const EvalInfo& ei) {
 
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
+    const Color Them = ~Us;
 
     // Find the safe squares for our pieces inside the area defined by
     // SpaceMask[]. A square is unsafe if it is attacked by an enemy

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -72,7 +72,7 @@ namespace {
 
   // Helper templates used to detect a given material distribution
   template<Color Us> bool is_KXK(const Position& pos) {
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
+    const Color Them = ~Us;
     return  !pos.count<PAWN>(Them)
           && pos.non_pawn_material(Them) == VALUE_ZERO
           && pos.non_pawn_material(Us) >= RookValueMg;
@@ -85,7 +85,7 @@ namespace {
   }
 
   template<Color Us> bool is_KQKRPs(const Position& pos) {
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
+    const Color Them = ~Us;
     return  !pos.count<PAWN>(Us)
           && pos.non_pawn_material(Us) == QueenValueMg
           && pos.count<QUEEN>(Us)  == 1
@@ -99,7 +99,7 @@ namespace {
   template<Color Us>
   int imbalance(const int pieceCount[][PIECE_TYPE_NB]) {
 
-    const Color Them = (Us == WHITE ? BLACK : WHITE);
+    const Color Them = ~Us;
 
     int pt1, pt2, pc, v;
     int value = 0;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -228,7 +228,7 @@ Entry* probe(const Position& pos, Table& entries) {
 template<Color Us>
 Value Entry::shelter_storm(const Position& pos, Square ksq) {
 
-  const Color Them = (Us == WHITE ? BLACK : WHITE);
+  const Color Them = ~Us;
 
   Value safety = MaxSafetyBonus;
   Bitboard b = pos.pieces(PAWN) & (in_front_bb(Us, rank_of(ksq)) | rank_bb(ksq));


### PR DESCRIPTION
The .gitignore file prevents build targets from getting accidentally included.

The other changes should be neutral. See the definition of the ~ operator on Color: 

    inline Color operator~(Color c) {
      return Color(c ^ BLACK);
    }

The benchmark shows it's performance neutral although I didn't verify by disassembling the binary. 