### PR TITLE
Replace

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -623,7 +623,7 @@ namespace {
     {
         if (   depth <= ONE_PLY
             && eval + razor_margin(3 * ONE_PLY) <= alpha)
-            return qsearch<NonPV, false>(pos, ss, alpha, beta, DEPTH_ZERO);
+            return qsearch<NT, false>(pos, ss, alpha, beta, DEPTH_ZERO);
 
         Value ralpha = alpha - razor_margin(depth);
         Value v = qsearch<NonPV, false>(pos, ss, ralpha, ralpha+1, DEPTH_ZERO);


### PR DESCRIPTION
       if (   depth <= ONE_PLY
            && eval + razor_margin(3 * ONE_PLY) <= alpha)
            return qsearch<NonPV, false>(pos, ss, alpha, beta, DEPTH_ZERO);

by

        if (   depth <= ONE_PLY
            && eval + razor_margin(3 * ONE_PLY) <= alpha)
            return qsearch<NT, false>(pos, ss, alpha, beta, DEPTH_ZERO);

in razoring so that it works cleanly in pvnodes.

Non-functional change since currently razoring is only done in
non-pvnodes.