### PR TITLE
Add all second order mixed moments for two variables

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -35,7 +35,9 @@ void start_logger(const std::string& fname);
 
 void dbg_hit_on(bool b);
 void dbg_hit_on(bool c, bool b);
-void dbg_mean_of(int v);
+void dbg_stats_of(int v);
+void dbg_stats_of(int v, int w);
+
 void dbg_print();
 
 typedef std::chrono::milliseconds::rep TimePoint; // A value in milliseconds


### PR DESCRIPTION
Make possible to collect the stats for two variables simultaneously and slightly reformat output.

This can be used to give a quantitative, tournament condition answer to the question: are the quantities A and B orthogonal? 

For doing this, after this patch, it would be enough to use dbg_stats_of(A, B) and then ask cutechess-cli to redirect cerr to the desired file.