### PR TITLE
[ADD] file .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Never ignore .gitignore itself
+!.gitignore
+
+# ignore compilation results
+src/stockfish
+src/stockfish.exe
+src/*.o
+src/.depend
+src/*~
+src/core
+src/bench.txt
+src/*.gcda
+src/syzygy/*.o
+src/syzygy/*.gcda


### PR DESCRIPTION
This commit adds the file .gitignore to the repository.

Now files created by compiling Stockfish will be ignored by Git.
This way a made compilation of Stockfish can never be added to a
commit (by accident).

The content of .gitignore have been created based on the output of
$ make clean

@mcostalba If you prefer to merge from a different branch then master, you can also merge this commit from the branch gitignore, of my fork.
