### PR TITLE
SImplify other checks (2)

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -423,13 +423,11 @@ namespace {
   Score Evaluation<T>::evaluate_king() {
 
     const Color     Them = (Us == WHITE ? BLACK : WHITE);
-    const Direction Up   = (Us == WHITE ? NORTH : SOUTH);
     const Bitboard  Camp = (Us == WHITE ? AllSquares ^ Rank6BB ^ Rank7BB ^ Rank8BB
                                         : AllSquares ^ Rank1BB ^ Rank2BB ^ Rank3BB);
 
     const Square ksq = pos.square<KING>(Us);
     Bitboard weak, b, b1, b2, safe, unsafeChecks;
-    int kingDanger;
 
     // King shelter and enemy pawns storm
     Score score = pe->king_safety<Us>(pos, ksq);
@@ -442,7 +440,7 @@ namespace {
               & ~attackedBy2[Us]
               & (attackedBy[Us][KING] | attackedBy[Us][QUEEN] | ~attackedBy[Us][ALL_PIECES]);
 
-        kingDanger = unsafeChecks = 0;
+        int kingDanger = unsafeChecks = 0;
 
         // Analyse the safe enemy's checks which are possible on next move
         safe  = ~pos.pieces(Them);
@@ -478,9 +476,8 @@ namespace {
             unsafeChecks |= b;
 
         // Unsafe or occupied checking squares will also be considered, as long as
-        // the square is not defended by our pawns or occupied by a blocked pawn.
-        unsafeChecks &= ~(   attackedBy[Us][PAWN]
-                          | (pos.pieces(Them, PAWN) & shift<Up>(pos.pieces(PAWN))));
+        // the square is in the attacker's mobility area.
+        unsafeChecks &= mobilityArea[Them];
 
         kingDanger +=        kingAttackersCount[Them] * kingAttackersWeight[Them]
                      + 102 * kingAdjacentZoneAttacksCount[Them]


### PR DESCRIPTION
Replace an intricate definition with a more natural one.

Master was excluding squares occupied by a pawn which was blocked by a pawn. 
This version excludes any squares occupied by a pawn which is blocked by "something"

Passed STC
http://tests.stockfishchess.org/tests/view/5a2f557b0ebc590ccbb8bc0d
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 44211 W: 8009 L: 7928 D: 28274

and LTC
http://tests.stockfishchess.org/tests/view/5a301d440ebc590ccbb8bc80
LLR: 2.95 (-2.94,2.94) [-3.00,1.00]
Total: 31958 W: 4108 L: 4002 D: 23848

bench 5000136