### PR TITLE
Tweak stat bonus

### DIFF
--- a/src/endgame.cpp
+++ b/src/endgame.cpp
@@ -86,30 +86,6 @@ namespace {
 } // namespace
 
 
-/// Endgames members definitions
-
-Endgames::Endgames() {
-
-  add<KPK>("KPK");
-  add<KNNK>("KNNK");
-  add<KBNK>("KBNK");
-  add<KRKP>("KRKP");
-  add<KRKB>("KRKB");
-  add<KRKN>("KRKN");
-  add<KQKP>("KQKP");
-  add<KQKR>("KQKR");
-
-  add<KNPK>("KNPK");
-  add<KNPKB>("KNPKB");
-  add<KRPKR>("KRPKR");
-  add<KRPKB>("KRPKB");
-  add<KBPKB>("KBPKB");
-  add<KBPKN>("KBPKN");
-  add<KBPPKB>("KBPPKB");
-  add<KRPPKRP>("KRPPKRP");
-}
-
-
 /// Mate with KX vs K. This function is used to evaluate positions with
 /// king and plenty of material vs a lone king. It simply gives the
 /// attacking side a bonus for driving the defending king towards the edge

--- a/src/endgame.h
+++ b/src/endgame.h
@@ -64,6 +64,7 @@ enum EndgameCode {
 
 /// Endgame functions can be of two types depending on whether they return a
 /// Value or a ScaleFactor.
+
 template<EndgameCode E> using
 eg_type = typename std::conditional<(E < SCALING_FUNCTIONS), Value, ScaleFactor>::type;
 
@@ -103,21 +104,40 @@ class Endgames {
     return std::get<std::is_same<T, ScaleFactor>::value>(maps);
   }
 
-  template<EndgameCode E, typename T = eg_type<E>, typename P = Ptr<T>>
+  template<EndgameCode E, typename T = eg_type<E>>
   void add(const std::string& code) {
 
     StateInfo st;
-    map<T>()[Position().set(code, WHITE, &st).material_key()] = P(new Endgame<E>(WHITE));
-    map<T>()[Position().set(code, BLACK, &st).material_key()] = P(new Endgame<E>(BLACK));
+    map<T>()[Position().set(code, WHITE, &st).material_key()] = Ptr<T>(new Endgame<E>(WHITE));
+    map<T>()[Position().set(code, BLACK, &st).material_key()] = Ptr<T>(new Endgame<E>(BLACK));
   }
 
   std::pair<Map<Value>, Map<ScaleFactor>> maps;
 
 public:
-  Endgames();
+  Endgames() {
+
+    add<KPK>("KPK");
+    add<KNNK>("KNNK");
+    add<KBNK>("KBNK");
+    add<KRKP>("KRKP");
+    add<KRKB>("KRKB");
+    add<KRKN>("KRKN");
+    add<KQKP>("KQKP");
+    add<KQKR>("KQKR");
+
+    add<KNPK>("KNPK");
+    add<KNPKB>("KNPKB");
+    add<KRPKR>("KRPKR");
+    add<KRPKB>("KRPKB");
+    add<KBPKB>("KBPKB");
+    add<KBPKN>("KBPKN");
+    add<KBPPKB>("KBPPKB");
+    add<KRPPKRP>("KRPPKRP");
+  }
 
   template<typename T>
-  EndgameBase<T>* probe(Key key) {
+  const EndgameBase<T>* probe(Key key) {
     return map<T>().count(key) ? map<T>()[key].get() : nullptr;
   }
 };

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -542,7 +542,7 @@ namespace {
                 score += ThreatByRank * (int)relative_rank(Them, s);
         }
 
-        b = (pos.pieces(Them, QUEEN) | weak) & attackedBy[Us][ROOK];
+        b = weak & attackedBy[Us][ROOK];
         while (b)
         {
             Square s = pop_lsb(&b);
@@ -557,7 +557,7 @@ namespace {
 
         score += Hanging * popcount(weak & ~attackedBy[Them][ALL_PIECES]);
 
-        b =  weak & nonPawnEnemies & attackedBy[Them][ALL_PIECES];
+        b = weak & nonPawnEnemies & attackedBy[Them][ALL_PIECES];
         score += Overload * popcount(b);
     }
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -21,7 +21,6 @@
 #ifndef EVALUATE_H_INCLUDED
 #define EVALUATE_H_INCLUDED
 
-#include <atomic>
 #include <string>
 
 #include "types.h"

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -152,7 +152,7 @@ Entry* probe(const Position& pos) {
 
   // OK, we didn't find any special evaluation function for the current material
   // configuration. Is there a suitable specialized scaling function?
-  EndgameBase<ScaleFactor>* sf;
+  const EndgameBase<ScaleFactor>* sf;
 
   if ((sf = pos.this_thread()->endgames.probe<ScaleFactor>(key)) != nullptr)
   {

--- a/src/material.h
+++ b/src/material.h
@@ -56,9 +56,9 @@ struct Entry {
   }
 
   Key key;
-  EndgameBase<Value>* evaluationFunction;
-  EndgameBase<ScaleFactor>* scalingFunction[COLOR_NB]; // Could be one for each
-                                                       // side (e.g. KPKP, KBPsKs)
+  const EndgameBase<Value>* evaluationFunction;
+  const EndgameBase<ScaleFactor>* scalingFunction[COLOR_NB]; // Could be one for each
+                                                             // side (e.g. KPKP, KBPsKs)
   int16_t value;
   uint8_t factor[COLOR_NB];
   Phase gamePhase;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -85,14 +85,14 @@ enum StatsParams { NOT_USED = 0 };
 /// unsuccessful during the current search, and is used for reduction and move
 /// ordering decisions. It uses 2 tables (one for each color) indexed by
 /// the move's from and to squares, see chessprogramming.wikispaces.com/Butterfly+Boards
-typedef Stats<int16_t, 10368, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyHistory;
+typedef Stats<int16_t, 10692, COLOR_NB, int(SQUARE_NB) * int(SQUARE_NB)> ButterflyHistory;
 
 /// CounterMoveHistory stores counter moves indexed by [piece][to] of the previous
 /// move, see chessprogramming.wikispaces.com/Countermove+Heuristic
 typedef Stats<Move, NOT_USED, PIECE_NB, SQUARE_NB> CounterMoveHistory;
 
 /// CapturePieceToHistory is addressed by a move's [piece][to][captured piece type]
-typedef Stats<int16_t, 10368, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToHistory;
+typedef Stats<int16_t, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB> CapturePieceToHistory;
 
 /// PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
 typedef Stats<int16_t, 29952, PIECE_NB, SQUARE_NB> PieceToHistory;

--- a/src/pawns.cpp
+++ b/src/pawns.cpp
@@ -208,7 +208,7 @@ Value Entry::evaluate_shelter(const Position& pos, Square ksq) {
   constexpr Direction Down = (Us == WHITE ? SOUTH : NORTH);
   constexpr Bitboard  BlockRanks = (Us == WHITE ? Rank1BB | Rank2BB : Rank8BB | Rank7BB);
 
-  Bitboard b = pos.pieces(PAWN) & (forward_ranks_bb(Us, ksq) | rank_bb(ksq));
+  Bitboard b = pos.pieces(PAWN) & ~forward_ranks_bb(Them, ksq);
   Bitboard ourPawns = b & pos.pieces(Us);
   Bitboard theirPawns = b & pos.pieces(Them);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -985,11 +985,9 @@ moves_loop: // When in check, search starts from here
 
           if (captureOrPromotion) // (~5 Elo)
           {
-              // Increase reduction by comparing opponent's stat score
-              if ((ss-1)->statScore >= 0)
-                  r += ONE_PLY;
-
-              r -= r ? ONE_PLY : DEPTH_ZERO;
+              // Decrease reduction by comparing opponent's stat score
+              if ((ss-1)->statScore < 0)
+                  r -= ONE_PLY;
           }
           else
           {
@@ -1030,10 +1028,10 @@ moves_loop: // When in check, search starts from here
                   r += ONE_PLY;
 
               // Decrease/increase reduction for moves with a good/bad history (~30 Elo)
-              r = std::max(DEPTH_ZERO, (r / ONE_PLY - ss->statScore / 20000) * ONE_PLY);
+              r -= ss->statScore / 20000 * ONE_PLY;
           }
 
-          Depth d = std::max(newDepth - r, ONE_PLY);
+          Depth d = std::max(newDepth - std::max(r, DEPTH_ZERO), ONE_PLY);
 
           value = -search<NonPV>(pos, ss+1, -(alpha+1), -alpha, d, true);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -82,7 +82,7 @@ namespace {
   // History and stats update bonus, based on depth
   int stat_bonus(Depth depth) {
     int d = depth / ONE_PLY;
-    return d > 17 ? 0 : 31 * d * d + 62 * d - 62;
+    return d > 17 ? 0 : 33 * d * d + 66 * d - 66;
   }
 
   // Skill structure is used to implement strength limit

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -82,7 +82,7 @@ namespace {
   // History and stats update bonus, based on depth
   int stat_bonus(Depth depth) {
     int d = depth / ONE_PLY;
-    return d > 17 ? 0 : 32 * d * d + 64 * d - 64;
+    return d > 17 ? 0 : 31 * d * d + 62 * d - 62;
   }
 
   // Skill structure is used to implement strength limit


### PR DESCRIPTION
Increase stat bonus by 1/32 and adjust the table divisor of main and capture history to 10692.

STC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 28437 W: 6444 L: 6166 D: 15827 
http://tests.stockfishchess.org/tests/view/5b579b4d0ebc5902bdb87139

LTC:
LLR: 2.96 (-2.94,2.94) [0.00,4.00]
Total: 111204 W: 19160 L: 18644 D: 73400 
http://tests.stockfishchess.org/tests/view/5b57a7c60ebc5902bdb872d3

Bench: 4778882